### PR TITLE
Add basic KVMI event support for CR/MSR/interrupt/mem_access (v5)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(map-addr map-addr.c)
 target_link_libraries(map-addr vmi_shared)
 
+add_executable(cr3-load cr3-load.c)
+target_link_libraries(cr3-load vmi_shared)
+
 add_executable(map-symbol map-symbol.c)
 target_link_libraries(map-symbol vmi_shared)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(map-addr vmi_shared)
 add_executable(cr3-event-example cr3-event-example.c)
 target_link_libraries(cr3-event-example vmi_shared)
 
+add_executable(mem-event-example mem-event-example.c)
+target_link_libraries(mem-event-example vmi_shared)
+
 add_executable(map-symbol map-symbol.c)
 target_link_libraries(map-symbol vmi_shared)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(map-addr map-addr.c)
 target_link_libraries(map-addr vmi_shared)
 
-add_executable(cr3-load cr3-load.c)
-target_link_libraries(cr3-load vmi_shared)
+add_executable(cr3-event-example cr3-event-example.c)
+target_link_libraries(cr3-event-example vmi_shared)
 
 add_executable(map-symbol map-symbol.c)
 target_link_libraries(map-symbol vmi_shared)

--- a/examples/cr3-event-example.c
+++ b/examples/cr3-event-example.c
@@ -43,6 +43,8 @@ static void close_handler(int sig)
 
 event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event)
 {
+    (void)vmi;
+    (void)event;
     return 0;
 }
 

--- a/examples/cr3-load.c
+++ b/examples/cr3-load.c
@@ -1,0 +1,131 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+
+event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event)
+{
+    return 0;
+}
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi;
+    status_t status;
+    vmi_init_data_t init_data = {0};
+
+    /* this is the VM or file that we are looking at */
+    if (argc < 2) {
+        printf("Usage: %s <vmname> [<socket>]\n", argv[0]);
+        return 1;
+    }
+
+    char *name = argv[1];
+
+    if (argc == 3) {
+        char *path = argv[2];
+
+        // fill init_data
+        init_data.count = 1;
+        init_data.entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data.entry[0].data = strdup(path);
+    }
+
+    /* initialize the libvmi library */
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, &init_data,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+
+    struct sigaction act;
+    /* for a clean exit */
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    /* pause the vm for consistent memory access */
+    if (vmi_pause_vm(vmi) != VMI_SUCCESS) {
+        printf("Failed to pause VM\n");
+        goto error_exit;
+    }
+
+    vmi_event_t cr3_event = {0};
+    cr3_event.version = VMI_EVENTS_VERSION;
+    cr3_event.type = VMI_EVENT_REGISTER;
+    cr3_event.callback = cr3_callback;
+
+    /* Observe only write events to the given register.
+     *   NOTE: read events are unsupported at this time.
+     */
+    cr3_event.reg_event.reg = CR3;
+    cr3_event.reg_event.in_access = VMI_REGACCESS_W;
+
+    // register event
+    if (vmi_register_event(vmi, &cr3_event) == VMI_FAILURE)
+        goto error_exit;
+
+    if (vmi_resume_vm(vmi) ==  VMI_FAILURE)
+        goto error_exit;
+
+    while (!interrupted) {
+        printf("listening...\n");
+        status = vmi_events_listen(vmi, 500);
+        if (status == VMI_FAILURE)
+            printf("Failed to  listen on events\n");
+    }
+
+    if (vmi_clear_event(vmi, &cr3_event, NULL) == VMI_FAILURE)
+        goto error_exit;
+
+error_exit:
+    fprintf(stderr, "Failure\n");
+
+    /* cleanup any memory associated with the LibVMI instance */
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/examples/mem-event-example.c
+++ b/examples/mem-event-example.c
@@ -1,0 +1,153 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+event_response_t mem_cb(vmi_instance_t vmi, vmi_event_t *event)
+{
+    return 0;
+}
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi = {0};
+    vmi_init_data_t init_data = {0};
+    vmi_mode_t mode = {0};
+    vmi_event_t mem_event = {0};
+    struct sigaction act = {0};
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <name of VM> [<socket path>]\n", argv[0]);
+        exit(1);
+    }
+
+    // Arg 1 is the VM name.
+    char *name = argv[1];
+
+
+    // kvmi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        // fill init_data
+        init_data.count = 1;
+        init_data.entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data.entry[0].data = strdup(path);
+    }
+
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, &init_data, &mode)) {
+        fprintf(stderr, "Failed to get access mode\n");
+        return 1;
+    }
+
+    if (VMI_FAILURE ==
+            vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, &init_data, NULL)) {
+        fprintf(stderr, "Failed to init LibVMI library.\n");
+        return 1;
+    }
+
+    vmi_init_paging(vmi, 0);
+    printf("LibVMI init succeeded!\n");
+
+    // pause vm
+    if (VMI_FAILURE ==  vmi_pause_vm(vmi)) {
+        fprintf(stderr, "Failed to pause vm\n");
+        goto error_exit;
+    }
+
+    // get rip
+    uint64_t rip;
+    if (VMI_FAILURE == vmi_get_vcpureg(vmi, &rip, RIP, 0)) {
+        fprintf(stderr, "Failed to get current RIP\n");
+        goto error_exit;
+    }
+
+    // get dtb
+    uint64_t cr3;
+    if (VMI_FAILURE == vmi_get_vcpureg(vmi, &cr3, CR3, 0)) {
+        fprintf(stderr, "Failed to get current CR3\n");
+        goto error_exit;
+    }
+    uint64_t dtb = cr3 & ~(0xfff);
+
+    // get gpa
+    uint64_t paddr;
+    if (VMI_FAILURE == vmi_pagetable_lookup(vmi, dtb, rip, &paddr)) {
+        fprintf(stderr, "Failed to find current paddr\n");
+        goto error_exit;
+    }
+
+    uint64_t gfn = paddr >> 12;
+    /* register a mem event */
+    SETUP_MEM_EVENT(&mem_event, gfn, VMI_MEMACCESS_X, mem_cb, false);
+
+    printf("Setting X memory event at RIP 0x%"PRIx64", GPA 0x%"PRIx64", GFN 0x%"PRIx64"\n",
+           rip, paddr, gfn);
+    if (VMI_FAILURE == vmi_register_event(vmi, &mem_event)) {
+        fprintf(stderr, "Failed to register mem event\n");
+        goto error_exit;
+    }
+
+    // resuming
+    if (VMI_FAILURE == vmi_resume_vm(vmi)) {
+        fprintf(stderr, "Failed to resume vm\n");
+        goto error_exit;
+    }
+
+    printf("Waiting for events...\n");
+    while (!interrupted) {
+        vmi_events_listen(vmi,500);
+    }
+    printf("Finished with test.\n");
+
+error_exit:
+    vmi_clear_event(vmi, &mem_event, NULL);
+
+    vmi_resume_vm(vmi);
+
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/examples/mem-event-example.c
+++ b/examples/mem-event-example.c
@@ -35,11 +35,14 @@ static bool interrupted = false;
 
 static void close_handler(int sig)
 {
+    (void)sig;
     interrupted = true;
 }
 
 event_response_t mem_cb(vmi_instance_t vmi, vmi_event_t *event)
 {
+    (void)vmi;
+
     char str_access[4] = {'_', '_', '_', '\0'};
     if (event->mem_event.out_access & VMI_MEMACCESS_R) str_access[0] = 'R';
     if (event->mem_event.out_access & VMI_MEMACCESS_W) str_access[1] = 'W';

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -34,7 +34,7 @@
 event_response_t msr_write_cb(vmi_instance_t vmi, vmi_event_t *event)
 {
     vmi = vmi;
-    printf("MSR write happened: MSR=%x Value=%lx\n", event->reg_event.msr, event->reg_event.value);
+    printf("MSR write happened: MSR=0x%"PRIx32" Value=0x%"PRIx64"\n", event->reg_event.msr, event->reg_event.value);
     return VMI_EVENT_RESPONSE_NONE;
 }
 

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -50,6 +50,7 @@ int main (int argc, char **argv)
 {
     vmi_instance_t vmi;
     struct sigaction act;
+    vmi_init_data_t init_data = {0};
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -61,17 +62,27 @@ int main (int argc, char **argv)
     char *name = NULL;
 
     if (argc < 2) {
-        fprintf(stderr, "Usage: msr_events_example <name of VM>\n");
+        fprintf(stderr, "Usage: msr_events_example <name of VM> [socket path]\n");
         exit(1);
     }
 
     // Arg 1 is the VM name.
     name = argv[1];
 
+    // KVMi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        // fill init_data
+        init_data.count = 1;
+        init_data.entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data.entry[0].data = strdup(path);
+    }
+
     /* initialize the libvmi library */
     if (VMI_FAILURE ==
             vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
-                              NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+                              &init_data, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -97,13 +97,22 @@ int main (int argc, char **argv)
     msr_event.reg_event.in_access = VMI_REGACCESS_W;
     msr_event.callback = msr_write_cb;
 
-    vmi_register_event(vmi, &msr_event);
+    if (VMI_FAILURE == vmi_register_event(vmi, &msr_event)) {
+        fprintf(stderr, "Failed to set MSR event\n");
+        goto error_exit;
+    }
 
     printf("Waiting for events...\n");
     while (!interrupted) {
-        vmi_events_listen(vmi,500);
+        if (VMI_FAILURE == vmi_events_listen(vmi,500)) {
+            fprintf(stderr, "Failed to listen on VMI events\n");
+            goto error_exit;
+        }
     }
     printf("Finished with test.\n");
+
+error_exit:
+    vmi_clear_event(vmi, &msr_event, NULL);
 
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);

--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -10,6 +10,7 @@ set(libvmi_src
     strmatch.c
     write.c
     memory.c
+    msr-index.c
     arch/arch_interface.c
     arch/intel.c
     arch/amd64.c

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1392,8 +1392,10 @@ kvm_set_mem_access(
             return VMI_FAILURE;
     }
 
+    // set page access
+    long long unsigned int gpa = gpfn << 12;
     for (unsigned int i = 0; i < vmi->num_vcpus; i++) {
-        if (kvmi_set_page_access(kvm->kvmi_dom, i, (long long unsigned int*)&gpfn, &kvmi_access, 1)) {
+        if (kvmi_set_page_access(kvm->kvmi_dom, i, &gpa, &kvmi_access, 1)) {
             errprint("%s error: unable to set page access on GPFN 0x%" PRIx64 "\n", __func__, gpfn);
             return VMI_FAILURE;
         }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1038,9 +1038,17 @@ status_t kvm_set_reg_access(
 
     // check reg
     switch (event->reg) {
+        case CR0:
+            event_flags |= KVMI_EVENT_CR_FLAG;
+            kvmi_reg = 0;
+            break;
         case CR3:
             event_flags |= KVMI_EVENT_CR_FLAG;
             kvmi_reg = 3;
+            break;
+        case CR4:
+            event_flags |= KVMI_EVENT_CR_FLAG;
+            kvmi_reg = 4;
             break;
         default:
             errprint("%s: unhandled register %" PRIu64"\n", __func__, event->reg);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -44,6 +44,7 @@
 #include <libvirt/virterror.h>
 
 #include "private.h"
+#include "msr-index.h"
 #include "driver/driver_wrapper.h"
 #include "driver/memory_cache.h"
 #include "driver/kvm/kvm.h"

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1431,6 +1431,9 @@ status_t kvm_set_reg_access(
                 kvmi_reg = msr_index[msr_all[i]];
                 if (kvmi_control_msr(kvm->kvmi_dom, vcpu, kvmi_reg, enable)) {
                     errprint("%s: failed to set MSR event for %s\n", __func__, msr_to_str[msr_all[i]]);
+                    // this call fails on MSR_HYPERVISOR
+                    // to avoid breaking MSR_ALL feature, we simply continue
+                    // and print an error message
                     continue;
                 }
             }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1372,10 +1372,14 @@ status_t kvm_set_reg_access(
         case MSR_ALL:
             event_flags |= KVMI_EVENT_MSR_FLAG;
             break;
-        case MSR_STAR:
+        case MSR_ANY:
             event_flags |= KVMI_EVENT_MSR_FLAG;
-            kvmi_reg = 0xc0000081;
+            kvmi_reg = event->msr;
             break;
+        case MSR_FLAGS ... MSR_TSC_AUX:
+        case MSR_STAR ... MSR_HYPERVISOR:
+            errprint("%s error: use MSR_ANY type for specific MSR event registration\n", __FUNCTION__);
+            return VMI_FAILURE;
         default:
             errprint("%s: unhandled register %" PRIu64"\n", __func__, event->reg);
             return VMI_FAILURE;
@@ -1415,7 +1419,7 @@ status_t kvm_set_reg_access(
             if (event_flags & KVMI_EVENT_MSR_FLAG)
                 if (kvmi_control_msr(kvm->kvmi_dom, i, kvmi_reg, enable)) {
                     errprint("%s: failed to set MSR event for %s: %s\n", __func__,
-                             msr_to_str[event->reg], strerror(errno));
+                             msr_to_str[kvmi_reg], strerror(errno));
                     goto error_exit;
                 }
         }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -244,6 +244,18 @@ process_interrupt(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     return VMI_SUCCESS;
 }
 
+static status_t
+process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi || !kvmi_event)
+        return VMI_FAILURE;
+#endif
+
+    dbprint(VMI_DEBUG_KVM, "--Received pagefault event\n");
+    return VMI_SUCCESS;
+}
+
 void *
 kvm_get_memory_kvmi(vmi_instance_t vmi, addr_t paddr, uint32_t length) {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
@@ -576,6 +588,7 @@ kvm_init_vmi(
         // fill event dispatcher
         kvm->process_event[KVMI_EVENT_CR] = &process_register;
         kvm->process_event[KVMI_EVENT_BREAKPOINT] = &process_interrupt;
+        kvm->process_event[KVMI_EVENT_PF] = &process_pagefault;
     }
 
     return kvm_setup_live_mode(vmi);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1043,7 +1043,7 @@ status_t kvm_set_reg_access(
             kvmi_reg = 3;
             break;
         default:
-            dbprint(VMI_DEBUG_KVM, "--Reg access: unhandled register %" PRIu64"\n", event->reg);
+            errprint("%s: unhandled register %" PRIu64"\n", __func__, event->reg);
             return VMI_FAILURE;
     }
 
@@ -1067,13 +1067,13 @@ status_t kvm_set_reg_access(
     // enable event monitoring for all vcpus
     for (unsigned int i = 0; i < vmi->num_vcpus; i++) {
         if (kvmi_control_events(kvm->kvmi_dom, i, event_flags)) {
-            dbprint(VMI_DEBUG_KVM, "--Reg access: kvmi_control_events failed\n");
+            errprint("%s: kvmi_control_events failed\n", __func__);
             goto error_exit;
         }
 
         if (event_flags & KVMI_EVENT_CR_FLAG)
             if (kvmi_control_cr(kvm->kvmi_dom, i, kvmi_reg, enable)) {
-                dbprint(VMI_DEBUG_KVM, "--Reg access: kvmi_control_cr failed\n");
+                errprint("%s: failed\n", __func__);
                 goto error_exit;
             }
     }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1369,6 +1369,9 @@ kvm_set_mem_access(
         case VMI_MEMACCESS_N:
             kvmi_access = 0;
             break;
+        case VMI_MEMACCESS_R:
+            kvmi_access &= ~KVMI_PAGE_ACCESS_R;
+            break;
         case VMI_MEMACCESS_W:
             kvmi_access &= ~KVMI_PAGE_ACCESS_W;
             break;

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -288,6 +288,8 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     //      msr_event
     libvmi_event->reg_event.value = kvmi_event->event.msr.new_value;
     libvmi_event->reg_event.previous = kvmi_event->event.msr.old_value;
+    // TODO
+    // libvmi_event->reg_event.out_access
 
     // call user callback
     return call_event_callback(vmi, libvmi_event, kvmi_event);
@@ -365,6 +367,9 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
             libvmi_event->mem_event.out_access = out_access;
             libvmi_event->mem_event.gla = kvmi_event->event.page_fault.gva;
             libvmi_event->mem_event.offset = kvmi_event->event.page_fault.gpa & VMI_BIT_MASK(0, 11);
+            // TODO
+            // libvmi_event->mem_event.valid
+            // libvmi_event->mem_event.gptw
 
             // call user callback
             return call_event_callback(vmi, libvmi_event, kvmi_event);
@@ -386,6 +391,10 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
                 libvmi_event->mem_event.out_access = out_access;
                 libvmi_event->mem_event.gla = kvmi_event->event.page_fault.gva;
                 libvmi_event->mem_event.offset = kvmi_event->event.page_fault.gpa & VMI_BIT_MASK(0, 11);
+                // TODO
+                // libvmi_event->mem_event.valid
+                // libvmi_event->mem_event.gptw
+
 
                 // call user callback
                 if (VMI_FAILURE == call_event_callback(vmi, libvmi_event, kvmi_event))

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -364,6 +364,7 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
             libvmi_event->x86_regs = &regs;
             fill_ev_common_kvmi_to_libvmi(kvmi_event, libvmi_event);
             //      mem_event
+            libvmi_event->mem_event.gfn = gfn;
             libvmi_event->mem_event.out_access = out_access;
             libvmi_event->mem_event.gla = kvmi_event->event.page_fault.gva;
             libvmi_event->mem_event.offset = kvmi_event->event.page_fault.gpa & VMI_BIT_MASK(0, 11);
@@ -388,6 +389,7 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
                 libvmi_event->x86_regs = &regs;
                 fill_ev_common_kvmi_to_libvmi(kvmi_event, libvmi_event);
                 //      mem_event
+                libvmi_event->mem_event.gfn = gfn;
                 libvmi_event->mem_event.out_access = out_access;
                 libvmi_event->mem_event.gla = kvmi_event->event.page_fault.gva;
                 libvmi_event->mem_event.offset = kvmi_event->event.page_fault.gpa & VMI_BIT_MASK(0, 11);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -983,6 +983,10 @@ status_t kvm_events_listen(
     unsigned int ev_id = 0;
 
     kvm_instance_t *kvm = kvm_get_instance(vmi);
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!kvm || !kvm->kvmi_dom)
+        return VMI_FAILURE;
+#endif
 
     // wait next event
     if (kvmi_wait_event(kvm->kvmi_dom, timeout)) {

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1139,3 +1139,13 @@ error_exit:
     }
     return VMI_FAILURE;
 }
+
+status_t
+kvm_set_intr_access(
+    vmi_instance_t vmi,
+    interrupt_event_t* event,
+    bool enabled)
+{
+
+    return VMI_SUCCESS;
+}

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1309,11 +1309,19 @@ kvm_set_mem_access(
         vmi_mem_access_t page_access_flag,
         uint16_t UNUSED(vmm_pagetable_id))
 {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi) {
+        errprint("%s: invalid vmi handle\n", __func__);
+        return VMI_FAILURE;
+    }
+#endif
     unsigned char kvmi_access;
     kvm_instance_t *kvm = kvm_get_instance(vmi);
 #ifdef ENABLE_SAFETY_CHECKS
-    if (!kvm)
+    if (!kvm || !kvm->kvmi_dom) {
         errprint("%s: invalid kvm handle\n", __func__);
+        return VMI_FAILURE;
+    }
 #endif
 
     // get previous access type

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1349,7 +1349,7 @@ kvm_set_mem_access(
     }
 #endif
     static bool pf_enabled = false;
-    unsigned char kvmi_access;
+    unsigned char kvmi_access, kvmi_orig_access;
     kvm_instance_t *kvm = kvm_get_instance(vmi);
 #ifdef ENABLE_SAFETY_CHECKS
     if (!kvm || !kvm->kvmi_dom) {
@@ -1365,7 +1365,7 @@ kvm_set_mem_access(
         for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
             if (kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_PF_FLAG)) {
                 pf_enabled_succeeded = false;
-                errprint("%s: Fail to enable PF events on VCPU %u\n", vcpu);
+                errprint("%s: Fail to enable PF events on VCPU %u\n", __func__, vcpu);
                 break;
             }
         }
@@ -1379,11 +1379,8 @@ kvm_set_mem_access(
     }
 
     // get previous access type
-    // only if not VMI_MEMACCESS_N and VMI_MEMACCESS_RWX,
-    // in which case we simply remove all permissions
-    if (page_access_flag != VMI_MEMACCESS_N && page_access_flag != VMI_MEMACCESS_RWX)
-        if (kvmi_get_page_access(kvm->kvmi_dom, 0, gpfn, &kvmi_access))
-            return VMI_FAILURE;
+    if (kvmi_get_page_access(kvm->kvmi_dom, 0, gpfn, &kvmi_orig_access))
+        return VMI_FAILURE;
 
     // check access type and convert to KVMI
     switch (page_access_flag) {
@@ -1391,19 +1388,19 @@ kvm_set_mem_access(
             kvmi_access = 0;
             break;
         case VMI_MEMACCESS_R:
-            kvmi_access &= ~KVMI_PAGE_ACCESS_R;
+            kvmi_access = kvmi_orig_access & ~KVMI_PAGE_ACCESS_R;
             break;
         case VMI_MEMACCESS_W:
-            kvmi_access &= ~KVMI_PAGE_ACCESS_W;
+            kvmi_access = kvmi_orig_access & ~KVMI_PAGE_ACCESS_W;
             break;
         case VMI_MEMACCESS_X:
-            kvmi_access &= ~KVMI_PAGE_ACCESS_X;
+            kvmi_access = kvmi_orig_access & ~KVMI_PAGE_ACCESS_X;
             break;
         case VMI_MEMACCESS_RW:
-            kvmi_access &= ~(KVMI_PAGE_ACCESS_R | KVMI_PAGE_ACCESS_W);
+            kvmi_access = kvmi_orig_access & ~(KVMI_PAGE_ACCESS_R | KVMI_PAGE_ACCESS_W);
             break;
         case VMI_MEMACCESS_WX:
-            kvmi_access &= ~(KVMI_PAGE_ACCESS_W | KVMI_PAGE_ACCESS_X);
+            kvmi_access = kvmi_orig_access & ~(KVMI_PAGE_ACCESS_W | KVMI_PAGE_ACCESS_X);
             break;
         case VMI_MEMACCESS_RWX:
             kvmi_access = 0;
@@ -1414,12 +1411,18 @@ kvm_set_mem_access(
     }
 
     // set page access
+    bool page_access_succeeded = true;
     long long unsigned int gpa = gpfn << 12;
-    for (unsigned int i = 0; i < vmi->num_vcpus; i++) {
-        if (kvmi_set_page_access(kvm->kvmi_dom, i, &gpa, &kvmi_access, 1)) {
+    for (unsigned int vcpu=0; vcpu < vmi->num_vcpus; vcpu++) {
+        if (kvmi_set_page_access(kvm->kvmi_dom, vcpu, &gpa, &kvmi_access, 1)) {
+            page_access_succeeded = false;
             errprint("%s error: unable to set page access on GPFN 0x%" PRIx64 "\n", __func__, gpfn);
-            return VMI_FAILURE;
+            break;
         }
+    }
+    if (!page_access_succeeded) {
+        for (unsigned int vcpu=0; vcpu < vmi->num_vcpus; vcpu++)
+            kvmi_set_page_access(kvm->kvmi_dom, vcpu, &gpa, &kvmi_orig_access, 1);
     }
 
     dbprint(VMI_DEBUG_KVM, "--Done setting memaccess on GPFN: 0x%" PRIx64 "\n", gpfn);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1266,11 +1266,6 @@ status_t kvm_events_listen(
     if (VMI_FAILURE == kvm->process_event[ev_reason](vmi, event))
         goto error_exit;
 
-
-//    // ack
-//    if (reply_continue(kvm->kvmi_dom, event) == VMI_FAILURE)
-//        goto error_exit;
-
     return VMI_SUCCESS;
 error_exit:
     if (event)

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -308,6 +308,9 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     // TODO: how can the callback specifiy a new value for the MSR ?
     // libvmi_event.reg_event.xxx
 
+    // the reply new value will be used anyway,
+    // write the new val from the kvmi event
+    rpl.msr.new_val = kvmi_event->event.msr.new_value;
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }
 

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1078,6 +1078,9 @@ status_t kvm_set_reg_access(
             }
     }
 
+    dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on register %" PRIu64"\n",
+            (enable ? "enabling" : "disabling"),
+            event->reg);
     return VMI_SUCCESS;
 error_exit:
     // disable monitoring

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1035,6 +1035,10 @@ status_t kvm_set_reg_access(
     bool enable = false;
 
     kvm_instance_t *kvm = kvm_get_instance(vmi);
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!kvm || !kvm->kvmi_dom)
+        return VMI_FAILURE;
+#endif
 
     // check reg
     switch (event->reg) {

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -133,6 +133,17 @@ process_register(vmi_instance_t vmi, struct kvmi_dom_event *event)
     return VMI_SUCCESS;
 }
 
+static status_t
+process_interrupt(vmi_instance_t vmi, struct kvmi_dom_event *event)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi || !event)
+        return VMI_FAILURE;
+#endif
+    dbprint(VMI_DEBUG_KVM, "--Received interrupt event\n");
+    return VMI_SUCCESS;
+}
+
 void *
 kvm_get_memory_kvmi(vmi_instance_t vmi, addr_t paddr, uint32_t length) {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
@@ -464,6 +475,7 @@ kvm_init_vmi(
     if (init_flags & VMI_INIT_EVENTS) {
         // fill event dispatcher
         kvm->process_event[KVMI_EVENT_CR] = &process_register;
+        kvm->process_event[KVMI_EVENT_BREAKPOINT] = &process_interrupt;
     }
 
     return kvm_setup_live_mode(vmi);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -249,7 +249,7 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         return VMI_FAILURE;
     }
 #endif
-    dbprint(VMI_DEBUG_KVM, "--Received MSR event, 0x%"PRIx32"\n", kvmi_event->event.msr.msr);
+    dbprint(VMI_DEBUG_KVM, "--Received MSR event on index 0x%"PRIx32"\n", kvmi_event->event.msr.msr);
 
     // lookup vmi event
     vmi_event_t *libvmi_event = NULL;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -95,6 +95,9 @@ status_t kvm_pause_vm(
     vmi_instance_t vmi);
 status_t kvm_resume_vm(
     vmi_instance_t vmi);
+status_t kvm_events_listen(
+    vmi_instance_t vmi,
+    uint32_t timeout);
 status_t kvm_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t* event);
@@ -138,6 +141,7 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.is_pv_ptr = &kvm_is_pv;
     driver.pause_vm_ptr = &kvm_pause_vm;
     driver.resume_vm_ptr = &kvm_resume_vm;
+    driver.events_listen_ptr = &kvm_events_listen;
     driver.set_reg_access_ptr= &kvm_set_reg_access;
     vmi->driver = driver;
     return VMI_SUCCESS;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -95,6 +95,9 @@ status_t kvm_pause_vm(
     vmi_instance_t vmi);
 status_t kvm_resume_vm(
     vmi_instance_t vmi);
+status_t kvm_set_reg_access(
+    vmi_instance_t vmi,
+    reg_event_t* event);
 status_t kvm_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
@@ -135,6 +138,7 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.is_pv_ptr = &kvm_is_pv;
     driver.pause_vm_ptr = &kvm_pause_vm;
     driver.resume_vm_ptr = &kvm_resume_vm;
+    driver.set_reg_access_ptr= &kvm_set_reg_access;
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -105,6 +105,11 @@ status_t kvm_set_intr_access(
     vmi_instance_t vmi,
     interrupt_event_t* event,
     bool enabled);
+status_t kvm_set_mem_access(
+    vmi_instance_t vmi,
+    addr_t gpfn,
+    vmi_mem_access_t page_access_flag,
+    uint16_t vmm_pagetable_id);
 status_t kvm_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
@@ -148,6 +153,7 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.events_listen_ptr = &kvm_events_listen;
     driver.set_reg_access_ptr = &kvm_set_reg_access;
     driver.set_intr_access_ptr = &kvm_set_intr_access;
+    driver.set_mem_access_ptr = &kvm_set_mem_access;
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -101,6 +101,10 @@ status_t kvm_events_listen(
 status_t kvm_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t* event);
+status_t kvm_set_intr_access(
+    vmi_instance_t vmi,
+    interrupt_event_t* event,
+    bool enabled);
 status_t kvm_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
@@ -142,7 +146,8 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.pause_vm_ptr = &kvm_pause_vm;
     driver.resume_vm_ptr = &kvm_resume_vm;
     driver.events_listen_ptr = &kvm_events_listen;
-    driver.set_reg_access_ptr= &kvm_set_reg_access;
+    driver.set_reg_access_ptr = &kvm_set_reg_access;
+    driver.set_intr_access_ptr = &kvm_set_intr_access;
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -33,6 +33,7 @@
 
 #include "private.h"
 #include "libvirt_wrapper.h"
+#include "driver/kvm/include/kvmi/libkvmi.h"
 
 typedef struct kvm_instance {
     virConnectPtr conn;
@@ -46,6 +47,8 @@ typedef struct kvm_instance {
     pthread_mutex_t kvm_connect_mutex;
     pthread_cond_t kvm_start_cond;
     unsigned int expected_pause_count;
+    // dispatcher to handle VM events in each process_xxx functions
+    status_t (*process_event[KVMI_NUM_EVENTS])(vmi_instance_t vmi, struct kvmi_dom_event *event);
 } kvm_instance_t;
 
 static inline kvm_instance_t *

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -22,12 +22,13 @@
 #include <string.h>
 
 #include "private.h"
+#include "msr-index.h"
 #include "driver/driver_wrapper.h"
 #include "driver/xen/xen.h"
 #include "driver/xen/xen_private.h"
 #include "driver/xen/xen_events.h"
 #include "driver/xen/xen_events_private.h"
-#include "driver/xen/msr-index.h"
+
 
 /*
  * Event control functions
@@ -209,7 +210,7 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
                 }
             } else {
                 size_t i;
-                for (i=0; i<sizeof(msr_all)/sizeof(reg_t); i++) {
+                for (i=0; i<msr_all_len; i++) {
                     dbprint(VMI_DEBUG_XEN, "--Setting monitor MSR: %"PRIx32" to %i\n", msr_index[msr_all[i]], enable);
                     if ( xen->libxcw.xc_monitor_mov_to_msr2(xch, dom, msr_index[msr_all[i]], enable) )
                         dbprint(VMI_DEBUG_XEN, "--Setting monitor MSR: %"PRIx32" FAILED\n", msr_index[msr_all[i]]);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -94,6 +94,8 @@ void step_event_free(vmi_event_t *event, status_t rc)
 status_t events_init(vmi_instance_t vmi)
 {
     switch (vmi->mode) {
+        case VMI_KVM:
+            break;
         case VMI_XEN:
             break;
         default:

--- a/libvmi/msr-index.c
+++ b/libvmi/msr-index.c
@@ -103,3 +103,55 @@ const uint32_t msr_index[] = {
     [MSR_HYPERVISOR]             = 0x40000000
 };
 const unsigned int msr_index_len = sizeof(msr_index) / sizeof(uint32_t);
+
+const char* msr_to_str[] = {
+    [MSR_EFER]                   = "MSR_EFER",
+    [MSR_STAR]                   = "MSR_STAR",
+    [MSR_LSTAR]                  = "MSR_LSTAR",
+    [MSR_CSTAR]                  = "MSR_CSTAR",
+    [MSR_SYSCALL_MASK]           = "MSR_SYSCALL_MASK",
+    [MSR_SHADOW_GS_BASE]         = "MSR_SHADOW_GS_BASE",
+    [MSR_TSC_AUX]                = "MSR_TSC_AUX",
+
+    [MSR_MTRRfix64K_00000]       = "MSR_MTRRfix64K_00000",
+    [MSR_MTRRfix16K_80000]       = "MSR_MTRRfix16K_80000",
+    [MSR_MTRRfix16K_A0000]       = "MSR_MTRRfix16K_A0000",
+    [MSR_MTRRfix4K_C0000]        = "MSR_MTRRfix4K_C0000",
+    [MSR_MTRRfix4K_C8000]        = "MSR_MTRRfix4K_C8000",
+    [MSR_MTRRfix4K_D0000]        = "MSR_MTRRfix4K_D0000",
+    [MSR_MTRRfix4K_D8000]        = "MSR_MTRRfix4K_D8000",
+    [MSR_MTRRfix4K_E0000]        = "MSR_MTRRfix4K_E0000",
+    [MSR_MTRRfix4K_E8000]        = "MSR_MTRRfix4K_E8000",
+    [MSR_MTRRfix4K_F0000]        = "MSR_MTRRfix4K_F0000",
+    [MSR_MTRRfix4K_F8000]        = "MSR_MTRRfix4K_F8000",
+    [MSR_MTRRdefType]            = "MSR_MTRRdefType",
+
+    [MSR_IA32_MC0_CTL]           = "MSR_IA32_MC0_CTL",
+    [MSR_IA32_MC0_STATUS]        = "MSR_IA32_MC0_STATUS",
+    [MSR_IA32_MC0_ADDR]          = "MSR_IA32_MC0_ADDR",
+    [MSR_IA32_MC0_MISC]          = "MSR_IA32_MC0_MISC",
+    [MSR_IA32_MC1_CTL]           = "MSR_IA32_MC1_CTL",
+    [MSR_IA32_MC0_CTL2]          = "MSR_IA32_MC0_CTL2",
+
+    [MSR_AMD_PATCHLEVEL]         = "MSR_AMD_PATCHLEVEL",
+
+    [MSR_AMD64_TSC_RATIO]        = "MSR_AMD64_TSC_RATIO",
+
+    [MSR_IA32_P5_MC_ADDR]        = "MSR_IA32_P5_MC_ADDR",
+    [MSR_IA32_P5_MC_TYPE]        = "MSR_IA32_P5_MC_TYPE",
+    [MSR_IA32_TSC]               = "MSR_IA32_TSC",
+    [MSR_IA32_PLATFORM_ID]       = "MSR_IA32_PLATFORM_ID",
+    [MSR_IA32_EBL_CR_POWERON]    = "MSR_IA32_EBL_CR_POWERON",
+    [MSR_IA32_EBC_FREQUENCY_ID]  = "MSR_IA32_EBC_FREQUENCY_ID",
+
+    [MSR_IA32_FEATURE_CONTROL]   = "MSR_IA32_FEATURE_CONTROL",
+
+    [MSR_IA32_SYSENTER_CS]       = "MSR_IA32_SYSENTER_CS",
+    [MSR_IA32_SYSENTER_ESP]      = "MSR_IA32_SYSENTER_ESP",
+    [MSR_IA32_SYSENTER_EIP]      = "MSR_IA32_SYSENTER_EIP",
+
+    [MSR_IA32_MISC_ENABLE]       = "MSR_IA32_MISC_ENABLE",
+
+    [MSR_HYPERVISOR]             = "MSR_HYPERVISOR"
+};
+const unsigned int msr_to_str_len = sizeof(msr_to_str) / sizeof(char*);

--- a/libvmi/msr-index.c
+++ b/libvmi/msr-index.c
@@ -1,26 +1,4 @@
-/* The LibVMI Library is an introspection library that simplifies access to
- * memory in a target virtual machine or in a file containing a dump of
- * a system's physical memory.  LibVMI is based on the XenAccess Library.
- *
- * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
- *
- * This file is part of LibVMI.
- *
- * LibVMI is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * LibVMI is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
- */
-#ifndef MSR_INDEX_H
-#define MSR_INDEX_H
+#include "msr-index.h"
 
 const reg_t msr_all[] = {
     MSR_EFER,
@@ -72,6 +50,7 @@ const reg_t msr_all[] = {
 
     MSR_HYPERVISOR,
 };
+const unsigned int msr_all_len = sizeof(msr_all) / sizeof(reg_t);
 
 const uint32_t msr_index[] = {
     [MSR_EFER]                   = 0xc0000080, /* extended feature register */
@@ -123,5 +102,4 @@ const uint32_t msr_index[] = {
 
     [MSR_HYPERVISOR]             = 0x40000000
 };
-
-#endif /* MSR_INDEX_H */
+const unsigned int msr_index_len = sizeof(msr_index) / sizeof(uint32_t);

--- a/libvmi/msr-index.h
+++ b/libvmi/msr-index.h
@@ -30,4 +30,7 @@ extern const unsigned int msr_all_len;
 extern const uint32_t msr_index[];
 extern const unsigned int msr_index_len;
 
+extern const char* msr_to_str[];
+extern const unsigned int msr_to_str_len;
+
 #endif /* MSR_INDEX_H */

--- a/libvmi/msr-index.h
+++ b/libvmi/msr-index.h
@@ -1,0 +1,33 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MSR_INDEX_H
+#define MSR_INDEX_H
+
+#include "libvmi.h"
+
+extern const reg_t msr_all[];
+extern const unsigned int msr_all_len;
+
+extern const uint32_t msr_index[];
+extern const unsigned int msr_index_len;
+
+#endif /* MSR_INDEX_H */


### PR DESCRIPTION
Hi,

this PR adds basic event support for
- `CR`
- `MSR`
- `memory`
- `interrupt (int 3)`

# Implementation 

## Details

- no event response logic is implemented ATM, simply reply to continue execution
- `kvm_set_reg_access`
    - handles `CR0/CR3/CR4`
    - handles `MSR_ANY`, where the MSR index is specified in `reg_event.msr` field
    - handles `MSR_ALL` by looping over all MSRs in Libvmi MSR index `msr_all`
    - `CR0/CR3/CR4` kvmi equivalent reg values are hardcoded
    - `VMI_REGACCESS_R` and `VMI_REGACCESS_RW` not supported (?)
    - doesn't support `MSR_HYPERVISOR`: `0x40000000`
    - on failure (a call to a VCPU failed, `goto error_exit`), it disables everything, but without checking the return value. (any ideas how to improve that ?)

- `msr-event-example`
    - modified to accept kvmi socket path (optional)
    - modified to init libvmi without os config, so can be init when OS boots, and intercept MSR being setup

- `kvm_set_intr_access`
    - simply call `kvmi_control_events` for every VCPU, enabling breakpint, or disabling everything

- `kvm_set_mem_access`
    - declares a `static` variable, and checks it to enable `KVMI_EVENT_PF_FLAG` on the first call, if necessary, this avoids to enable them at `kvm_init_vmi`, even though the app might never use them. What do you think ?
    - assumes `VMI_MEMACCESS_N` and `VMI_MEMACCESS_RWX` are the same (is it though ?)
    - hardcoded `12` shift to get a gpa from a `gfn`
    - again, per VCPU events and page config makes it difficult for error handling

- `kvm_events_listen`
    - wait next event
    - pop from event queue
    - checks if event reason makes sense
    - call the handler if defined

For all events i'm assigning a pointer to a `x86_regs` struct from the stack,
and call `fill_ev_common_kvmi_to_libvmi` to fill the regs.

-> Any suggestions of how this should be done ?

- `process_register`
    not handled because it doesn't work for CR3 when i tested :-)

- `process_msr`
    - TODO: fill `reg_event`
        - `out_access`

- `process_interrupt`
    - hardcoded page shift `12`
    - TODO: fill `interrupt_event`
        - `vector`
        - `type`
        - Should we set the `insn_length` here ?
        - What are `INT_NEXT` interrupts ?

- `process_pagefault`
    - hardcoded page shift `12`
    - TODO: fill `mem_event`
        - `valid`
        - `gptw`

- `process_pause_event`
    - we should never reach this code, since `kvm_resume_vm` should pop this type of event
    - print and error and return a failure

- `kvm_init_vmi`
    - set event handlers if `VMI_INIT_EVENTS`

## Notes

- `msr-index.h` has been moved from `libvmi/driver/xen/` to `libvmi`
- add enum to string `msr_to_str` array
- activating the same event/flag for every VCPU can be a bit cumbersome sometimes, and makes error handling more tricky in my opinion.
- sorry for this big PR, I wanted to makes multiples PR for every feature, but I ended up building static functions and helpers, so I had to stack them up.


## Issues

- catching `CR3` doesn't work as I expected (at context switch) (fix in https://github.com/KVM-VMI/kvm/pull/21)
- catching MSR_HYPERVISOR 0x40000000 is not supported by the API

# Future

## Fixes

- use a global event_flags for all VCPU, to store the old state and avoid erasing it

## V6

Rebase on https://github.com/KVM-VMI/libvmi/pull/8

cc @mdontu, @adlazar, @tklengyel

Thanks.
 
