### PR TITLE
Add support for pagefault injection in KVM driver

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -597,6 +597,32 @@ kvm_get_memsize(
     return VMI_SUCCESS;
 }
 
+status_t kvm_request_page_fault (
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    uint64_t virtual_address,
+    uint32_t error_code)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi) {
+        errprint("Invalid vmi handle\n");
+        return VMI_FAILURE;
+    }
+#endif
+    kvm_instance_t *kvm = kvm_get_instance(vmi);
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!kvm || !kvm->kvmi_dom) {
+        errprint("Invalid kvm/kvmi handles\n");
+        return VMI_FAILURE;
+    }
+#endif
+    if (kvmi_inject_page_fault(kvm->kvmi_dom, vcpu, virtual_address, error_code))
+        return VMI_FAILURE;
+
+    dbprint(VMI_DEBUG_KVM, "--Page fault injected at 0x%"PRIx64"\n", virtual_address);
+    return VMI_SUCCESS;
+}
+
 status_t
 kvm_get_vcpuregs(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -68,6 +68,11 @@ status_t kvm_get_memsize(
     vmi_instance_t vmi,
     uint64_t *allocate_ram_size,
     addr_t *maximum_physical_address);
+status_t kvm_request_page_fault (
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    uint64_t virtual_address,
+    uint32_t error_code);
 status_t kvm_get_vcpureg(
     vmi_instance_t vmi,
     uint64_t *value,
@@ -121,6 +126,7 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.set_name_ptr = &kvm_set_name;
     driver.write_ptr = &kvm_write;
     driver.get_memsize_ptr = &kvm_get_memsize;
+    driver.request_page_fault_ptr = &kvm_request_page_fault;
     driver.get_vcpureg_ptr = &kvm_get_vcpureg;
     driver.get_vcpuregs_ptr = &kvm_get_vcpuregs;
     driver.set_vcpureg_ptr = &kvm_set_vcpureg;


### PR DESCRIPTION
This PR adds support for pagefault injection using the `KVMi` patches v5.

The function used is `kvmi_inject_page_fault`

cc @mdontu, @adlazar, @tklengyel