### PR TITLE
cmake: make events.h as public header for KVM

### DIFF
--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -115,6 +115,7 @@ if (ENABLE_KVM)
         target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
         # CMAKE_DL_LIBS -> dlopen* lib
         target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
+        list(APPEND VMI_PUBLIC_HEADERS events.h)
         list(APPEND VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
     endif ()
 endif ()


### PR DESCRIPTION
Small fix when installing the KVM driver, `events.h` should be installed too.