### PR TITLE
CMake 3.13 refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
+# allow to link libraries with targets not built in the same directory
+cmake_policy(SET CMP0079 NEW)
+
 # set cmake module path, to search in cmake/modules first
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 # set cmake module path, to search in cmake/modules first
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,11 +112,13 @@ configure_file(libvmi.pc.in ${PROJECT_BINARY_DIR}/libvmi.pc)
 install(FILES ${PROJECT_BINARY_DIR}/libvmi.pc DESTINATION
     "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
 
-configure_file(libvmi/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 # include <libvmi/libvmi.h> "config.h", "private.h" and <glib.h>
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR} libvmi ${GLIB_INCLUDE_DIRS})
 add_definitions(-DHAVE_CONFIG_H)
 add_subdirectory(libvmi)
+# configure config.h after processing libvmi subdir
+# as it may have disabled some features due to unmet dependencies
+configure_file(libvmi/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 add_subdirectory(tools)
 if (ENABLE_TESTING)
     # this command should always be called in the root CMakeLists.txt

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Dependencies
 ------------
 The following libraries are used in building this code:
 
-- ``CMake`` (``>= 3.1``)
+- ``CMake`` (``>= 3.13``)
 
 - ``libtool`` Generic library support script
 

--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -25,25 +25,29 @@ add_library(vmi OBJECT ${libvmi_src})
 # force -fPIC
 set_property(TARGET vmi PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-set(VMI_PUBLIC_HEADERS
+# define Libvmi public headers to be installed
+# Note: We use a property because we want to modify this list
+# in subdirectories
+set_property(GLOBAL PROPERTY G_VMI_PUBLIC_HEADERS
     libvmi.h
     libvmi_extra.h
     slat.h
     x86.h)
 
-# list of external dependencies, used by libtool for the static library
-set(VMI_PUBLIC_DEPS "")
+# define list of external dependencies, used by libtool for the static library
+# Note: use a property here as well
+set_property(GLOBAL PROPERTY G_VMI_PUBLIC_DEPS "")
 
 # create libvmi.so
 add_library (vmi_shared SHARED $<TARGET_OBJECTS:vmi>)
 # performance.c uses math.h in implementation
 target_link_libraries(vmi_shared PRIVATE m)
-list(APPEND VMI_PUBLIC_DEPS m)
+set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS m)
 # one libvmi_extra.h function returns a GSList*
 target_link_libraries(vmi_shared PUBLIC ${GLIB_LDFLAGS})
 # cleanup GLIB_LDFLAGS (remove -l prefix)
 string(REGEX REPLACE "-l" "" GLIB_LDFLAGS ${GLIB_LDFLAGS})
-list(APPEND VMI_PUBLIC_DEPS ${GLIB_LDFLAGS})
+set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${GLIB_LDFLAGS})
 set_target_properties(vmi_shared PROPERTIES OUTPUT_NAME "vmi")
 # set soname
 set_target_properties(vmi_shared PROPERTIES
@@ -57,132 +61,15 @@ if (ENABLE_STATIC)
     set_target_properties(vmi_static PROPERTIES OUTPUT_NAME "vmi")
 endif ()
 
-# workaround CMake bug
-# target_sources doesn't work with generated files in subdirectories
 if (ENABLE_CONFIGFILE)
-    find_package(FLEX)
-    set_package_properties(FLEX PROPERTIES
-        DESCRIPTION "Scanner generator for lexing in C and C++"
-        URL "https://github.com/westes/flex"
-        TYPE OPTIONAL
-        PURPOSE "Lexing LibVMI configuration file")
-    find_package(BISON)
-    set_package_properties(BISON PROPERTIES
-        DESCRIPTION "Parser generator"
-        URL "https://www.gnu.org/software/bison"
-        TYPE OPTIONAL
-        PURPOSE "Parsing LibVMI configuration file")
-    if (NOT FLEX_FOUND OR NOT BISON_FOUND)
-        set(ENABLE_CONFIGFILE OFF CACHE BOOL "Enable config file" FORCE)
-        message(WARNING "Cannot find flex or bison: config file parsing will be
-        disabled")
-    else ()
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scanner.c
-            COMMAND ${FLEX_EXECUTABLE}
-                --outfile=${CMAKE_CURRENT_BINARY_DIR}/scanner.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/config/lexicon.l
-            COMMENT "Generating scanner.c"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/config
-        )
-
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/parser.c
-            COMMAND ${BISON_EXECUTABLE}
-                --output=${CMAKE_CURRENT_BINARY_DIR}/parser.c
-                --defines=${CMAKE_CURRENT_BINARY_DIR}/grammar.h
-                ${CMAKE_CURRENT_SOURCE_DIR}/config/grammar.y
-            COMMENT "Generating parser.c"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/config
-        )
-
-        # build specific target for scanner.c and parser.c
-        # to remove Werror flag, otherwise flex and bison's generated
-        # source file won't compile
-        add_library(config_parser STATIC
-            ${CMAKE_CURRENT_BINARY_DIR}/scanner.c
-            ${CMAKE_CURRENT_BINARY_DIR}/parser.c
-        )
-
-        target_include_directories(config_parser PRIVATE
-            ${CMAKE_CURRENT_BINARY_DIR} # grammar.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/config # config_parser.h
-        )
-        # remove Werror flag just for config_parser
-        # compile with -fPIC to allow static linking
-        set_target_properties(config_parser PROPERTIES COMPILE_FLAGS "-Wno-error -fPIC")
-        # link with main libvmi library
-        target_link_libraries(vmi_shared PRIVATE config_parser)
-    endif ()
-endif ()
-
-if (ENABLE_KVM)
-    # common dependencies
-    find_package(Libvirt)
-    if (NOT Libvirt_FOUND)
-        set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
-        message(WARNING "Cannot find libvirt: disabling KVM driver")
-    else ()
-        if (ENABLE_KVM_LEGACY)
-            # legacy KVM driver
-            find_package(JSON-C)
-            set_package_properties(JSON-C PROPERTIES
-                PURPOSE "Dependency for KVM driver")
-            if (NOT JSON-C_FOUND)
-                set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
-                message(WARNING "Cannot find JSON: disabling KVM driver")
-            else ()
-                find_package(LibvmiRequest)
-            endif ()
-        else ()
-            # KVM driver based on KVMi series, API is exposed via libkvmi
-            find_package(Libkvmi)
-            if (NOT Libkvmi_FOUND)
-                set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
-                message(WARNING "Cannot find libkvmi: disabling KVM driver")
-            else ()
-                target_include_directories(vmi_shared PRIVATE
-                    ${Libkvmi_INCLUDE_DIRS})
-                target_link_libraries(vmi_shared PRIVATE ${Libkvmi_LIBRARIES})
-            endif ()
-        endif ()
-        target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
-        # CMAKE_DL_LIBS -> dlopen* lib
-        target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
-        list(APPEND VMI_PUBLIC_HEADERS events.h)
-        list(APPEND VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
-    endif ()
-endif ()
-
-
-if (ENABLE_BAREFLANK)
-    find_package(JSON-C)
-    set_package_properties(JSON-C PROPERTIES
-        PURPOSE "Dependency for Bareflank driver")
-    if (NOT JSON-C_FOUND)
-        set(ENABLE_BAREFLANK OFF CACHE BOOL "Build Bareflank driver" FORCE)
-        message(WARNING "Cannot find JSON: disabling Bareflank driver")
-    else ()
-        target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
-        target_link_libraries(vmi_shared PRIVATE ${JSON-C_LIBRARIES})
-        list(APPEND VMI_PUBLIC_DEPS ${JSON-C_LIBRARIES})
-    endif ()
+    add_subdirectory(config)
 endif ()
 
 add_subdirectory(driver)
 add_subdirectory(os)
 
-
-if (ENABLE_XEN)
-    find_package(Xen REQUIRED)
-    list(APPEND VMI_PUBLIC_HEADERS events.h)
-    # CMAKE_DL_LIBS -> dlopen* lib
-    target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS})
-    list(APPEND VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS})
-endif ()
-
 if (ENABLE_WINDOWS)
-    list(APPEND VMI_PUBLIC_HEADERS peparse.h)
+    set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_HEADERS peparse.h)
 endif ()
 
 if (ENABLE_ADDRESS_CACHE)
@@ -209,7 +96,7 @@ if (REKALL_PROFILES OR VOLATILITY_IST)
         endif ()
         target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
         target_link_libraries(vmi_shared PRIVATE ${JSON-C_LIBRARIES})
-        list(APPEND VMI_PUBLIC_DEPS ${JSON-C_LIBRARIES})
+        set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${JSON-C_LIBRARIES})
     endif ()
 endif ()
 
@@ -217,9 +104,14 @@ install(TARGETS vmi_shared DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 if (ENABLE_STATIC)
     install(TARGETS vmi_static DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 endif ()
+
+get_property(VMI_PUBLIC_HEADERS GLOBAL PROPERTY G_VMI_PUBLIC_HEADERS)
 install(FILES ${VMI_PUBLIC_HEADERS} DESTINATION include/libvmi)
 
+# remove duplicates
+get_property(VMI_PUBLIC_DEPS GLOBAL PROPERTY G_VMI_PUBLIC_DEPS)
 list(REMOVE_DUPLICATES VMI_PUBLIC_DEPS)
+
 set (DEPENDENCY_LIBS "")
 foreach (PUB_LIB ${VMI_PUBLIC_DEPS})
     set(DEPENDENCY_LIBS "${DEPENDENCY_LIBS} -l${PUB_LIB}")

--- a/libvmi/config/CMakeLists.txt
+++ b/libvmi/config/CMakeLists.txt
@@ -1,0 +1,54 @@
+find_package(FLEX)
+set_package_properties(FLEX PROPERTIES
+    DESCRIPTION "Scanner generator for lexing in C and C++"
+    URL "https://github.com/westes/flex"
+    TYPE OPTIONAL
+    PURPOSE "Lexing LibVMI configuration file")
+find_package(BISON)
+set_package_properties(BISON PROPERTIES
+    DESCRIPTION "Parser generator"
+    URL "https://www.gnu.org/software/bison"
+    TYPE OPTIONAL
+    PURPOSE "Parsing LibVMI configuration file")
+if (NOT FLEX_FOUND OR NOT BISON_FOUND)
+    set(ENABLE_CONFIGFILE OFF CACHE BOOL "Enable config file" FORCE)
+    message(WARNING "Cannot find flex or bison: config file parsing will be
+    disabled")
+else ()
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scanner.c
+        COMMAND ${FLEX_EXECUTABLE}
+            --outfile=${CMAKE_CURRENT_BINARY_DIR}/scanner.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/lexicon.l
+        COMMENT "Generating scanner.c"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/parser.c
+        COMMAND ${BISON_EXECUTABLE}
+            --output=${CMAKE_CURRENT_BINARY_DIR}/parser.c
+            --defines=${CMAKE_CURRENT_BINARY_DIR}/grammar.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/grammar.y
+        COMMENT "Generating parser.c"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    # build specific target for scanner.c and parser.c
+    # to remove Werror flag, otherwise flex and bison's generated
+    # source file won't compile
+    add_library(config_parser STATIC
+        ${CMAKE_CURRENT_BINARY_DIR}/scanner.c
+        ${CMAKE_CURRENT_BINARY_DIR}/parser.c
+    )
+
+    target_include_directories(config_parser PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR} # grammar.h
+        ${CMAKE_CURRENT_SOURCE_DIR} # config_parser.h
+    )
+    # remove Werror flag just for config_parser
+    # compile with -fPIC to allow static linking
+    set_target_properties(config_parser PROPERTIES COMPILE_FLAGS "-Wno-error -fPIC")
+    # link with main libvmi library
+    target_link_libraries(vmi_shared PRIVATE config_parser)
+endif ()

--- a/libvmi/driver/bareflank/CMakeLists.txt
+++ b/libvmi/driver/bareflank/CMakeLists.txt
@@ -1,4 +1,15 @@
-target_sources(vmi_shared PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/bareflank.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/hypercall.S
-)
+find_package(JSON-C)
+set_package_properties(JSON-C PROPERTIES
+    PURPOSE "Dependency for Bareflank driver")
+if (NOT JSON-C_FOUND)
+    set(ENABLE_BAREFLANK OFF CACHE BOOL "Build Bareflank driver" FORCE)
+    message(WARNING "Cannot find JSON: disabling Bareflank driver")
+else ()
+    target_sources(vmi_shared PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/bareflank.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/hypercall.S
+    )
+    target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
+    target_link_libraries(vmi_shared PRIVATE ${JSON-C_LIBRARIES})
+    set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${JSON-C_LIBRARIES})
+endif ()

--- a/libvmi/driver/kvm/CMakeLists.txt
+++ b/libvmi/driver/kvm/CMakeLists.txt
@@ -1,12 +1,58 @@
-target_sources(vmi_shared PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/kvm_common.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/libvirt_wrapper.c)
-
-if (ENABLE_KVM_LEGACY)
-    target_sources(vmi_shared PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/kvm_legacy.c)
+# common dependencies
+find_package(Libvirt)
+if (NOT Libvirt_FOUND)
+    set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
+    message(WARNING "Cannot find libvirt: disabling KVM driver")
 else ()
-    target_sources(vmi_shared PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/kvm.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/kvm_events.c)
+    if (ENABLE_KVM_LEGACY)
+        # legacy KVM driver
+        find_package(JSON-C)
+        set_package_properties(JSON-C PROPERTIES
+            PURPOSE "Dependency for KVM driver")
+        if (NOT JSON-C_FOUND)
+            set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
+            message(WARNING "Cannot find JSON: disabling KVM driver")
+        else ()
+            find_package(LibvmiRequest)
+            # add sources
+            # common
+            message("HEEERE")
+            target_sources(vmi_shared PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/kvm_common.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/libvirt_wrapper.c)
+            # legacy driver
+            target_sources(vmi_shared PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/kvm_legacy.c)
+            target_include_directories(vmi_shared PRIVATE ${JSON-C_INCLUDE_DIRS})
+            # CMAKE_DL_LIBS -> dlopen* lib
+            target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
+            set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS} ${JSON-C_LIBRARIES})
+        endif ()
+    else ()
+        # KVM driver based on KVMi series, API is exposed via libkvmi
+        find_package(Libkvmi)
+        if (NOT Libkvmi_FOUND)
+            set(ENABLE_KVM OFF CACHE BOOL "Build KVM driver" FORCE)
+            message(WARNING "Cannot find libkvmi: disabling KVM driver")
+        else ()
+            # add sources
+            # common
+            target_sources(vmi_shared PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/kvm_common.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/libvirt_wrapper.c)
+            # KVMi driver
+            target_sources(vmi_shared PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/kvm.c
+                ${CMAKE_CURRENT_SOURCE_DIR}/kvm_events.c)
+
+            target_include_directories(vmi_shared PRIVATE
+                ${Libkvmi_INCLUDE_DIRS})
+            target_link_libraries(vmi_shared PRIVATE ${Libkvmi_LIBRARIES})
+            # CMAKE_DL_LIBS -> dlopen* lib
+            target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS})
+            # expose events.h
+            set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_HEADERS events.h)
+            set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS})
+        endif ()
+    endif ()
 endif ()

--- a/libvmi/driver/xen/CMakeLists.txt
+++ b/libvmi/driver/xen/CMakeLists.txt
@@ -1,3 +1,9 @@
+find_package(Xen REQUIRED)
+set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_HEADERS events.h)
+# CMAKE_DL_LIBS -> dlopen* lib
+target_link_libraries(vmi_shared PRIVATE ${CMAKE_DL_LIBS})
+set_property(GLOBAL APPEND PROPERTY G_VMI_PUBLIC_DEPS ${CMAKE_DL_LIBS})
+
 target_sources(vmi_shared PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/altp2m.c
     ${CMAKE_CURRENT_SOURCE_DIR}/altp2m_private.h


### PR DESCRIPTION
- bump to CMake 3.13 (Debian Buster)
- move driver specific cmake code into `libvmi/driver/xxx/CMakeLists.txt`
- cleanup `libvmi/CMakeLists.txt`