### PR TITLE
Kvmi fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ configure
 depcomp
 install-sh
 **/.libs/*
+
+# IDE
+/.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: c
 
 # install libkvmi for all tests
 before_install:
-  - git clone https://github.com/KVM-VMI/kvm --branch kvmi --depth 1
-  - pushd kvm/tools/kvm/kvmi
+  # install in /tmp/kvm to avoid breaking astyle test
+  - git clone https://github.com/KVM-VMI/kvm --branch kvmi --depth 1 /tmp/kvm
+  - pushd /tmp/kvm/tools/kvm/kvmi
   - make
   - sudo make install
   - popd

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(va-pages vmi_shared)
 add_executable(event-example event-example.c)
 target_link_libraries(event-example vmi_shared)
 
+add_executable(fool-patchguard fool-patchguard.c)
+target_link_libraries(fool-patchguard vmi_shared)
+
 add_executable(interrupt-event-example interrupt-event-example.c)
 target_link_libraries(interrupt-event-example vmi_shared)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(map-addr vmi_shared)
 add_executable(cr3-event-example cr3-event-example.c)
 target_link_libraries(cr3-event-example vmi_shared)
 
+add_executable(descriptor-event-example descriptor-event-example.c)
+target_link_libraries(descriptor-event-example vmi_shared)
+
 add_executable(mem-event-example mem-event-example.c)
 target_link_libraries(mem-event-example vmi_shared)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,10 @@ to emulate the instruction stored in `event->emul_insn`.
 
 Intercepts and displays `CR3` events.
 
+## descriptor-event-example
+
+Intercepts descriptor register accesss events. (`IDTR`, `GDTR`, `LDTR`, `TR`)
+
 ## vmi-dump-memory
 
 Dumps the VM's physical memory to the given filepath.

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ _Note: Not compatible with the new KVM driver_
 
 Intercepts and displays `CR3` events.
 
-## dump-memory
+## vmi-dump-memory
 
 Dumps the VM's physical memory to the given filepath.
 
@@ -52,7 +52,7 @@ _Note: Not compatible with the new KVM driver_
 
 A simple execute memory access interception, configured on the current RIP.
 
-## module-list
+## vmi-module-list
 
 Displays the list of loaded modules, for Windows and linux.
 
@@ -60,7 +60,7 @@ Displays the list of loaded modules, for Windows and linux.
 
 A simple MSR event interception.
 
-## process-list
+## vmi-process-list
 
 Displays the VM's process list.
 
@@ -82,13 +82,13 @@ A Simple example monitoring for domain creation and deletion.
 
 _Note: Not compatible with the new KVM driver_
 
-## win-guid
+## vmi-win-guid
 
 Print the `GUID` and the `PE_HEADER` of the Windows kernel.
 
 _Note: Not compatible with the new KVM driver_
 
-## win-offsets
+## vmi-win-offsets
 
 Displays Windows kernel offsets based on a Rekall profile.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,17 @@ Dumps the VM's physical memory to the given filepath.
 
 A demo of the event API using `MSRs`, `memory access` and `CR3` events.
 
+## fool-patchguard
+
+Finds the index of `nt!NtLoadDriver` routine in the `SSDT`, and corrupts the entry.
+
+Then it waits for a Patchguard check to return fake data.
+
+Demonstrates how to use
+
+- `event->emul_read`
+- `VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA`
+
 ## interrupt-event-example
 
 A simple interrupt interception example that will display `int3` events.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,9 +5,6 @@ This folder contains a few examples of code using the LibVMI library.
 Note: some of them take an optional `[<socket>]` parameter. This refers to the
 `KVMi socket`, which needs to be specified when using the KVM driver.
 
-Not all examples have been modified to accept this `[<socket>]` parameter,
-and therefore are not compatible with the new KVM driver.
-
 ## breakpoint-emulate-example
 
 Recoiling on a software breakpoint via instruction emulation.
@@ -17,8 +14,6 @@ parameter) and sets a software breakpoint by writing `int3` interrupt.
 
 When the breakpoint is hit, use the `VMI_EVENT_RESPONSE_SET_EMUL_INSN` event response
 to emulate the instruction stored in `event->emul_insn`.
-
-_Note: Not compatible with the new KVM driver_
 
 ## cr3-event-example
 
@@ -39,8 +34,6 @@ A simple interrupt interception example that will display `int3` events.
 ## map-addr
 
 Display a page in hexadecimal at the given virtual address.
-
-_Note: Not compatible with the new KVM driver_
 
 ## map-symbol
 
@@ -68,34 +61,22 @@ Displays the VM's process list.
 
 A simple singlestep event interception. Also demonstrate how to manually toggle the singlestep once enabled.
 
-_Note: Not compatible with the new KVM driver_
-
 ## va-pages
 
 Displays the current process page tables upon each `CR3` load.
-
-_Note: Not compatible with the new KVM driver_
 
 ## wait-for-domain-example
 
 A Simple example monitoring for domain creation and deletion.
 
-_Note: Not compatible with the new KVM driver_
-
 ## vmi-win-guid
 
 Print the `GUID` and the `PE_HEADER` of the Windows kernel.
-
-_Note: Not compatible with the new KVM driver_
 
 ## vmi-win-offsets
 
 Displays Windows kernel offsets based on a Rekall profile.
 
-_Note: Not compatible with the new KVM driver_
-
 ## xen-emulate-response
 
 Sets an execute memory access trap on a virtual address and emulate the instruction to continue execution.
-
-_Note: Not compatible with the new KVM driver_

--- a/examples/breakpoint-emulate-example.c
+++ b/examples/breakpoint-emulate-example.c
@@ -115,6 +115,9 @@ int main (int argc, char **argv)
     struct sigaction act = {0};
     struct cb_data data = {0};
     int opcode_size = 0;
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
+
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -126,8 +129,8 @@ int main (int argc, char **argv)
     char *name = NULL;
 
     if (argc < 4) {
-        fprintf(stderr, "Usage: %s <name of VM> <symbol> <opcode size>\n", argv[0]);
-        return 1;
+        fprintf(stderr, "Usage: %s <name of VM> <symbol> <opcode size> [<socket>]\n", argv[0]);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
@@ -135,12 +138,22 @@ int main (int argc, char **argv)
     data.symbol = argv[2];
     opcode_size = atoi(argv[3]);
 
+    if (argc == 5) {
+        char *path = argv[4];
+
+        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
     // Initialize the libvmi library.
     if (VMI_FAILURE ==
-            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, NULL,
+            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data,
                               VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -148,7 +161,7 @@ int main (int argc, char **argv)
     // pause
     if (VMI_FAILURE == vmi_pause_vm(vmi)) {
         fprintf(stderr, "Failed to pause vm\n");
-        return 1;
+        goto error_exit;
     }
 
     // translate symbol to paddr
@@ -202,7 +215,7 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
-
+    retcode = 0;
 error_exit:
     // restore opcode
     if (data.emul.data[0])
@@ -210,6 +223,9 @@ error_exit:
     vmi_resume_vm(vmi);
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/breakpoint-emulate-example.c
+++ b/examples/breakpoint-emulate-example.c
@@ -224,8 +224,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return 0;
 }

--- a/examples/cr3-event-example.c
+++ b/examples/cr3-event-example.c
@@ -129,8 +129,10 @@ error_exit:
     /* cleanup any memory associated with the LibVMI instance */
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/cr3-event-example.c
+++ b/examples/cr3-event-example.c
@@ -54,11 +54,12 @@ int main (int argc, char **argv)
     status_t status;
     vmi_mode_t mode;
     vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
 
     /* this is the VM or file that we are looking at */
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <vmname> [<socket>]\n", argv[0]);
-        return 1;
+        return retcode;
     }
 
     char *name = argv[1];
@@ -121,6 +122,7 @@ int main (int argc, char **argv)
             printf("Failed to listen on events\n");
     }
 
+    retcode = 0;
 error_exit:
     vmi_clear_event(vmi, &cr3_event, NULL);
 
@@ -130,5 +132,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/cr3-event-example.c
+++ b/examples/cr3-event-example.c
@@ -50,9 +50,9 @@ event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event)
 
 int main (int argc, char **argv)
 {
-    vmi_instance_t vmi;
-    status_t status;
-    vmi_mode_t mode;
+    vmi_instance_t vmi = {0};
+    status_t status = VMI_FAILURE;
+    vmi_mode_t mode = {0};
     vmi_init_data_t *init_data = NULL;
     int retcode = 1;
 

--- a/examples/descriptor-event-example.c
+++ b/examples/descriptor-event-example.c
@@ -1,0 +1,167 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+event_response_t desc_cb(
+    __attribute__((unused)) vmi_instance_t vmi,
+    vmi_event_t *event)
+{
+    if (!event || !event->data) {
+        fprintf(stderr, "%s: invalid parameters\n", __func__);
+    }
+    int *stats = (int*)event->data;
+    char *desc_str = NULL;
+    switch (event->descriptor_event.descriptor) {
+        case VMI_DESCRIPTOR_IDTR:
+            desc_str = "IDTR";
+            stats[VMI_DESCRIPTOR_IDTR] += 1;
+            break;
+        case VMI_DESCRITPOR_GDTR:
+            desc_str = "GDTR";
+            stats[VMI_DESCRITPOR_GDTR] += 1;
+            break;
+        case VMI_DESCRIPTOR_LDTR:
+            desc_str = "LDTR";
+            stats[VMI_DESCRIPTOR_LDTR] += 1;
+            break;
+        case VMI_DESCRIPTOR_TR:
+            desc_str = "TR";
+            stats[VMI_DESCRIPTOR_TR] += 1;
+            break;
+        default:
+            fprintf(stderr, "Unexpected descriptor ID %d\n",
+                    event->descriptor_event.descriptor);
+            return VMI_EVENT_RESPONSE_NONE;
+    }
+
+    printf("[%d] Descriptor event: %s access on %s\n",
+           event->vcpu_id,
+           (event->descriptor_event.is_write) ? "write" : "read",
+           desc_str);
+
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi = {0};
+    vmi_mode_t mode = {0};
+    vmi_init_data_t *init_data = NULL;
+    vmi_event_t descriptor_event = {0};
+    struct sigaction act = {0};
+    int retcode = 1;
+
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    char *name = NULL;
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <name of VM> [<socket path>]\n", argv[0]);
+        return retcode;
+    }
+
+    // Arg 1 is the VM name.
+    name = argv[1];
+
+    // kvmi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        init_data = malloc(sizeof(vmi_init_data_t)+ sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, &mode)) {
+        fprintf(stderr, "Failed to get access mode\n");
+        goto error_exit;
+    }
+
+    if (VMI_FAILURE ==
+            vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, NULL)) {
+        fprintf(stderr, "Failed to init LibVMI library.\n");
+        goto error_exit;
+    }
+
+    printf("LibVMI init succeeded!\n");
+
+    /* Register event to track descriptor events */
+    memset(&descriptor_event, 0, sizeof(vmi_event_t));
+    descriptor_event.version = VMI_EVENTS_VERSION;
+    descriptor_event.type = VMI_EVENT_DESCRIPTOR_ACCESS;
+    descriptor_event.callback = &desc_cb;
+    // record stats
+    // VMI_DESCRIPTOR_TR is MAX value
+    int stats[VMI_DESCRIPTOR_TR+1] = {0};
+    descriptor_event.data = (void*)&stats;
+
+    vmi_register_event(vmi, &descriptor_event);
+
+    printf("Waiting for events...\n");
+    while (!interrupted) {
+        if (VMI_FAILURE == vmi_events_listen(vmi,500))
+            goto error_exit;
+    }
+    printf("Finished with test.\n");
+
+    // display stats
+    printf("Statistics:\n");
+    printf("\tIDTR access: %d\n", stats[VMI_DESCRIPTOR_IDTR]);
+    printf("\tGDTR access: %d\n", stats[VMI_DESCRITPOR_GDTR]);
+    printf("\tLDTR access: %d\n", stats[VMI_DESCRIPTOR_LDTR]);
+    printf("\tTR access: %d\n", stats[VMI_DESCRIPTOR_TR]);
+
+    retcode = 0;
+error_exit:
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    if (init_data) {
+        free(init_data->entry[0].data);
+        free(init_data);
+    }
+
+    return retcode;
+}

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -49,6 +49,7 @@ main(
     FILE *f = NULL;
     unsigned char memory[PAGE_SIZE];
     unsigned char zeros[PAGE_SIZE];
+    int retcode = 1;
 
     memset(zeros, 0, PAGE_SIZE);
     addr_t address = 0;
@@ -144,6 +145,7 @@ main(
         address += PAGE_SIZE;
     }
 
+    retcode = 0;
 error_exit:
     if (f)
         fclose(f);
@@ -157,5 +159,5 @@ error_exit:
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);
 
-    return 0;
+    return retcode;
 }

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -39,7 +39,7 @@ main(
     int argc,
     char **argv)
 {
-    if ( argc != 3 ) {
+    if ( argc < 3 ) {
         fprintf(stderr, "Usage: %s <name of VM> <dump file> [<socket>]", argv[0]);
         return 1;
     }
@@ -55,8 +55,7 @@ main(
     addr_t size = 0;
     vmi_mode_t mode;
     memory_map_t *memmap = NULL;
-    vmi_init_data_t *init_data = alloca(sizeof(vmi_init_data_t)
-                                        + (sizeof(vmi_init_data_entry_t) * 1));
+    vmi_init_data_t *init_data = NULL;
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];
@@ -67,6 +66,7 @@ main(
     if (argc == 4) {
         char *path = argv[3];
 
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
         init_data->count = 1;
         init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
         init_data->entry[0].data = strdup(path);
@@ -149,6 +149,8 @@ error_exit:
         fclose(f);
     if (memmap)
         free(memmap);
+    if (init_data)
+        free(init_data);
 
     free(filename);
 

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -40,7 +40,7 @@ main(
     char **argv)
 {
     if ( argc < 3 ) {
-        fprintf(stderr, "Usage: %s <name of VM> <dump file> [<socket>]", argv[0]);
+        fprintf(stderr, "Usage: %s <name of VM> <dump file> [<socket>]\n", argv[0]);
         return 1;
     }
 

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -151,8 +151,10 @@ error_exit:
         fclose(f);
     if (memmap)
         free(memmap);
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     free(filename);
 

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -180,8 +180,7 @@ int main (int argc, char **argv)
 
     char *name = NULL;
 
-    vmi_init_data_t *init_data = alloca(sizeof(vmi_init_data_t)
-                                        + (sizeof(vmi_init_data_entry_t) * 1));
+    vmi_init_data_t *init_data = NULL;
 
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
@@ -194,7 +193,7 @@ int main (int argc, char **argv)
     if (argc == 3) {
         char *path = argv[2];
 
-        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
         init_data->count = 1;
         init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
         init_data->entry[0].data = strdup(path);
@@ -342,6 +341,9 @@ int main (int argc, char **argv)
 
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -342,8 +342,10 @@ int main (int argc, char **argv)
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return 0;
 }

--- a/examples/fool-patchguard.c
+++ b/examples/fool-patchguard.c
@@ -1,0 +1,287 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+typedef struct cb_data {
+    addr_t ntload_driver_entry_addr;
+    emul_read_t emul_read;
+} cb_data_t;
+
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+
+event_response_t read_callback(vmi_instance_t vmi, vmi_event_t *event)
+{
+    (void)vmi;
+    cb_data_t *cb_data = (cb_data_t*)event->data;
+    event_response_t rsp = VMI_EVENT_RESPONSE_NONE;
+
+    char str_access[4] = {'_', '_', '_', '\0'};
+    if (event->mem_event.out_access & VMI_MEMACCESS_R) str_access[0] = 'R';
+    if (event->mem_event.out_access & VMI_MEMACCESS_W) str_access[1] = 'W';
+    if (event->mem_event.out_access & VMI_MEMACCESS_X) str_access[2] = 'X';
+
+    printf("%s: at 0x%"PRIx64", on frame 0x%"PRIx64", permissions: %s\n",
+           __func__, event->x86_regs->rip, event->mem_event.gfn, str_access);
+
+    if (event->x86_regs->rip == cb_data->ntload_driver_entry_addr) {
+        printf("READ attempt on NtLoadDriver SSDT entry !\n");
+        // set data to emulate
+        event->emul_read = &cb_data->emul_read;
+        // set response to emulate read data
+        rsp |= VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA;
+    }
+
+    return rsp;
+}
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi = {0};
+    struct sigaction act = {0};
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
+
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    char *name = NULL;
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
+        return retcode;
+    }
+
+    // Arg 1 is the VM name.
+    name = argv[1];
+
+    if (argc == 3) {
+        char *path = argv[2];
+
+        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
+    // Initialize the libvmi library.
+    if (VMI_FAILURE ==
+            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data,
+                              VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+        printf("Failed to init LibVMI library.\n");
+        goto error_exit;
+    }
+
+    printf("LibVMI init succeeded!\n");
+    uint8_t addr_width = vmi_get_address_width(vmi);
+
+    // pause
+    printf("Pausing VM\n");
+    if (VMI_FAILURE == vmi_pause_vm(vmi)) {
+        fprintf(stderr, "Failed to pause vm\n");
+        goto error_exit;
+    }
+
+    // read nt!KeServiceDescriptorTable
+    addr_t ke_sd_table_addr = 0;
+    if (VMI_FAILURE == vmi_translate_ksym2v(vmi, "KeServiceDescriptorTable", &ke_sd_table_addr)) {
+        fprintf(stderr, "Failed to translate KeServiceDescriptorTable symbol\n");
+        goto error_exit;
+    }
+    printf("nt!KeServiceDescriptorTable: 0x%" PRIx64 "\n", ke_sd_table_addr);
+
+    // read nt!KiServiceTable
+    addr_t ki_sv_table_addr = 0;
+    if (VMI_FAILURE == vmi_translate_ksym2v(vmi, "KiServiceTable", &ki_sv_table_addr)) {
+        fprintf(stderr, "Failed to translate KiServiceTable symbol\n");
+        goto error_exit;
+    }
+    printf("nt!KiServiceTable: 0x%" PRIx64 "\n", ki_sv_table_addr);
+
+    // read nt!NtLoadDriver
+    addr_t ntload_driver_addr = 0;
+    if (VMI_FAILURE == vmi_translate_ksym2v(vmi, "NtLoadDriver", &ntload_driver_addr)) {
+        fprintf(stderr, "Failed to translate NtAddDriverEntry symbol\n");
+        goto error_exit;
+    }
+    printf("nt!NtLoadDriver: 0x%" PRIx64 "\n", ntload_driver_addr);
+
+    /*
+     * Table's structure looks like the following
+     * (source: https://m0uk4.gitbook.io/notebooks/mouka/windowsinternal/ssdt-hook)
+
+        struct SSDTStruct
+        {
+            LONG* pServiceTable;
+            PVOID pCounterTable;
+        #ifdef _WIN64
+            ULONGLONG NumberOfServices;
+        #else
+            ULONG NumberOfServices;
+        #endif
+            PCHAR pArgumentTable;
+        };
+    */
+
+
+    //  read NumberOfServices
+    addr_t nb_services_addr = ke_sd_table_addr + (addr_width * 2);
+    addr_t nb_services = 0;
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, nb_services_addr, 0, &nb_services)) {
+        fprintf(stderr, "Failed to read SSDT.NumberOfServices field\n");
+        goto error_exit;
+    }
+    printf("SSDT.NumberOfServices: 0x%" PRIx64 "\n", nb_services);
+
+    // find NtAddrDriverEntry index in SSDT
+
+    int ntload_driver_index = -1;
+    for (int i = 0; i < (int)nb_services; i++) {
+        addr_t syscall_addr_entry = ki_sv_table_addr + (addr_width * i);
+        addr_t syscall_addr = 0;
+        if (VMI_FAILURE == vmi_read_addr_va(vmi, syscall_addr_entry, 0, &syscall_addr)) {
+            fprintf(stderr, "Failed to read syscall address\n");
+            goto error_exit;
+        }
+        // Debug
+        // printf("Syscall[%d]: 0x%" PRIx64 "\n", i, syscall_addr);
+        // find NtLoadDriver
+        if (syscall_addr == ntload_driver_addr) {
+            printf("Found NtLoadDriver SSDT entry: %d\n", i);
+            ntload_driver_index = i;
+            break;
+        }
+    }
+    if (ntload_driver_index == -1) {
+        fprintf(stderr, "Failed to find NtLoadDriver SSDT entry\n");
+        goto error_exit;
+    }
+
+    // corrupting pointer
+    printf("Corrupting NtLoadDriver SSDT entry\n");
+    addr_t ntload_driver_entry_addr = ki_sv_table_addr + (addr_width * ntload_driver_index);
+    addr_t corrupted_value = 0;
+    bool is_corrupted = false;
+    if (VMI_FAILURE == vmi_write_addr_va(vmi, ntload_driver_entry_addr, 0, &corrupted_value)) {
+        fprintf(stderr, "Failed to corrupt NtLoadDriver SSDT entry\n");
+        goto error_exit;
+    }
+    is_corrupted = true;
+
+    // flush page cache after write
+    vmi_pagecache_flush(vmi);
+
+    // reread NtLoadDriver SSDT entry
+    if (VMI_FAILURE == vmi_read_addr_va(vmi, ntload_driver_entry_addr, 0, &corrupted_value)) {
+        fprintf(stderr, "Failed to read NtLoadDriver SSDT entry\n");
+        goto error_exit;
+    }
+    printf("New NtLoadDriver SSDT entry value: 0x%" PRIx64 "\n", corrupted_value);
+
+    // protect corrupted SSDT entry using memory access event
+    //   get dtb
+    uint64_t cr3;
+    if (VMI_FAILURE == vmi_get_vcpureg(vmi, &cr3, CR3, 0)) {
+        fprintf(stderr, "Failed to get current CR3\n");
+        goto error_exit;
+    }
+    uint64_t dtb = cr3 & ~(0xfff);
+    // get paddr
+    uint64_t syscall_entry_paddr;
+    if (VMI_FAILURE == vmi_pagetable_lookup(vmi, dtb, ntload_driver_entry_addr, &syscall_entry_paddr)) {
+        fprintf(stderr, "Failed to find current paddr\n");
+        goto error_exit;
+    }
+    // get Guest Frame Number (gfn)
+    uint64_t syscall_entry_gfn = syscall_entry_paddr >> 12;
+    vmi_event_t read_event = {0};
+    SETUP_MEM_EVENT(&read_event, syscall_entry_gfn, VMI_MEMACCESS_R, read_callback, 0);
+    // add cb_data
+    cb_data_t cb_data = {0};
+    cb_data.ntload_driver_entry_addr = ntload_driver_entry_addr;
+    cb_data.emul_read.dont_free = 1;
+    cb_data.emul_read.size = sizeof(ntload_driver_addr);
+    memcpy(&cb_data.emul_read.data, &ntload_driver_addr, cb_data.emul_read.size);
+    // set event callback data
+    read_event.data = (void*)&cb_data;
+
+    printf("Registering read event on GFN 0x%" PRIx64 "\n", syscall_entry_gfn);
+    if (VMI_FAILURE == vmi_register_event(vmi, &read_event)) {
+        fprintf(stderr, "Failed to register event\n");
+        goto error_exit;
+    }
+
+    // resume
+    printf("Resuming VM\n");
+    if (VMI_FAILURE == vmi_resume_vm(vmi)) {
+        fprintf(stderr, "Failed to continue VM\n");
+        goto error_exit;
+    }
+    printf("Waiting for events...\n");
+    while (!interrupted) {
+        if (VMI_FAILURE == vmi_events_listen(vmi,500)) {
+            fprintf(stderr, "Failed to listen on VMI events\n");
+            goto error_exit;
+        }
+    }
+    printf("Finished with test.\n");
+
+    retcode = 0;
+error_exit:
+    if (is_corrupted) {
+        printf("Restoring NtLoadDriver SSDT entry\n");
+        // restore SSDT entry
+        if (VMI_FAILURE == vmi_write_addr_va(vmi, ntload_driver_entry_addr, 0, &ntload_driver_addr)) {
+            fprintf(stderr, "Failed to restore SSDT entry\n");
+        }
+    }
+    vmi_resume_vm(vmi);
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    if (init_data) {
+        free(init_data->entry[0].data);
+        free(init_data);
+    }
+
+    return 0;
+}

--- a/examples/fool-patchguard.c
+++ b/examples/fool-patchguard.c
@@ -73,6 +73,8 @@ int main (int argc, char **argv)
     vmi_instance_t vmi = {0};
     struct sigaction act = {0};
     vmi_init_data_t *init_data = NULL;
+    bool is_corrupted = false;
+    addr_t ntload_driver_entry_addr = 0;
     int retcode = 1;
 
     act.sa_handler = close_handler;
@@ -198,9 +200,8 @@ int main (int argc, char **argv)
 
     // corrupting pointer
     printf("Corrupting NtLoadDriver SSDT entry\n");
-    addr_t ntload_driver_entry_addr = ki_sv_table_addr + (addr_width * ntload_driver_index);
+    ntload_driver_entry_addr = ki_sv_table_addr + (addr_width * ntload_driver_index);
     addr_t corrupted_value = 0;
-    bool is_corrupted = false;
     if (VMI_FAILURE == vmi_write_addr_va(vmi, ntload_driver_entry_addr, 0, &corrupted_value)) {
         fprintf(stderr, "Failed to corrupt NtLoadDriver SSDT entry\n");
         goto error_exit;

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -71,8 +71,7 @@ int main (int argc, char **argv)
 {
     vmi_instance_t vmi;
     vmi_mode_t mode;
-    vmi_init_data_t *init_data = alloca(sizeof(vmi_init_data_t)
-                                        + (sizeof(vmi_init_data_entry_t) * 1));
+    vmi_init_data_t *init_data = NULL;
     struct sigaction act;
     act.sa_handler = close_handler;
     act.sa_flags = 0;
@@ -96,7 +95,7 @@ int main (int argc, char **argv)
     if (argc == 3) {
         char *path = argv[2];
 
-        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t)+ sizeof(vmi_init_data_entry_t));
         init_data->count = 1;
         init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
         init_data->entry[0].data = strdup(path);
@@ -104,13 +103,13 @@ int main (int argc, char **argv)
 
     if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, &mode)) {
         fprintf(stderr, "Failed to get access mode\n");
-        return 1;
+        goto error_exit;
     }
 
     if (VMI_FAILURE ==
             vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, NULL)) {
         fprintf(stderr, "Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -130,8 +129,12 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -136,8 +136,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -73,6 +73,8 @@ int main (int argc, char **argv)
     vmi_mode_t mode;
     vmi_init_data_t *init_data = NULL;
     struct sigaction act;
+    int retcode = 1;
+
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -85,7 +87,7 @@ int main (int argc, char **argv)
 
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <name of VM> [<socket path>]\n", argv[0]);
-        exit(1);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
@@ -129,6 +131,7 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+    retcode = 0;
 error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
@@ -136,5 +139,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -69,8 +69,8 @@ static void close_handler(int sig)
 
 int main (int argc, char **argv)
 {
-    vmi_instance_t vmi;
-    vmi_mode_t mode;
+    vmi_instance_t vmi = {0};
+    vmi_mode_t mode = {0};
     vmi_init_data_t *init_data = NULL;
     struct sigaction act;
     int retcode = 1;

--- a/examples/map-addr.c
+++ b/examples/map-addr.c
@@ -38,10 +38,15 @@ main(
     int argc,
     char **argv)
 {
-    if ( argc != 3 )
+    if ( argc < 3 ) {
+        fprintf(stderr, "Usage: %s <name of VM> <virtual address> [<socket>]\n", argv[0]);
         return 1;
+    }
 
-    vmi_instance_t vmi;
+    vmi_instance_t vmi = {0};
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
+
     char *memory = malloc(PAGE_SIZE);
 
     /* this is the VM or file that we are looking at */
@@ -51,9 +56,19 @@ main(
     char *addr_str = argv[2];
     addr_t addr = (addr_t) strtoul(addr_str, NULL, 16);
 
+    /* kvmi socket ? */
+    if (argc == 4) {
+        char *path = argv[3];
+
+        init_data = malloc(sizeof(vmi_init_data_t)+ sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
     /* initialize the libvmi library */
     if (VMI_FAILURE ==
-            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, init_data,
                               VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
         goto error_exit;
@@ -66,12 +81,15 @@ main(
     }
     vmi_print_hex(memory, PAGE_SIZE);
 
+    retcode = 0;
 error_exit:
     if (memory)
         free(memory);
+    if (init_data)
+        free(init_data);
 
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);
 
-    return 0;
+    return retcode;
 }

--- a/examples/map-addr.c
+++ b/examples/map-addr.c
@@ -85,8 +85,10 @@ main(
 error_exit:
     if (memory)
         free(memory);
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);

--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -83,8 +83,10 @@ main(
 error_exit:
     if (memory)
         free(memory);
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);

--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -38,11 +38,15 @@ main(
     int argc,
     char **argv)
 {
-    if ( argc != 3 )
+    if ( argc < 3 ) {
+        fprintf(stderr, "Usage: %s <name of VM> <symbol> [<socket>]\n", argv[0]);
         return 1;
+    }
 
-    vmi_instance_t vmi;
+    vmi_instance_t vmi = {0};
+    vmi_init_data_t *init_data = NULL;
     char *memory = malloc(PAGE_SIZE);
+    int retcode = 1;
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];
@@ -50,9 +54,19 @@ main(
     /* this is the symbol to map */
     char *symbol = argv[2];
 
+    /* kvmi socket ? */
+    if (argc == 4) {
+        char *path = argv[3];
+
+        init_data = malloc(sizeof(vmi_init_data_t)+ sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
     /* initialize the libvmi library */
     if (VMI_FAILURE ==
-            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, init_data,
                               VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
         goto error_exit;
@@ -65,12 +79,15 @@ main(
     }
     vmi_print_hex(memory, PAGE_SIZE);
 
+    retcode = 0;
 error_exit:
     if (memory)
         free(memory);
+    if (init_data)
+        free(init_data);
 
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);
 
-    return 0;
+    return retcode;
 }

--- a/examples/mem-event-example.c
+++ b/examples/mem-event-example.c
@@ -61,6 +61,8 @@ int main (int argc, char **argv)
     vmi_event_t mem_event = {0};
     struct sigaction act = {0};
     vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
+
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -71,7 +73,7 @@ int main (int argc, char **argv)
 
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <name of VM> [<socket path>]\n", argv[0]);
-        exit(1);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
@@ -153,6 +155,7 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+    retcode = 0;
 error_exit:
     vmi_clear_event(vmi, &mem_event, NULL);
 
@@ -164,5 +167,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/mem-event-example.c
+++ b/examples/mem-event-example.c
@@ -164,8 +164,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -37,8 +37,9 @@ main(
     int argc,
     char **argv)
 {
-    vmi_instance_t vmi;
-    addr_t next_module, list_head;
+    vmi_instance_t vmi = {0};
+    addr_t next_module = 0;
+    addr_t list_head = 0;
     // init_data for KVM socket, if needed
     vmi_init_data_t *init_data = NULL;
     int retcode = 1;

--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -155,8 +155,10 @@ error_exit:
     /* cleanup any memory associated with the libvmi instance */
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -41,10 +41,11 @@ main(
     addr_t next_module, list_head;
     // init_data for KVM socket, if needed
     vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
 
     if ( argc < 2 ) {
         fprintf(stderr, "Usage: %s <Name of VM> [socket]", argv[0]);
-        return 1;
+        return retcode;
     }
 
     /* this is the VM or file that we are looking at */
@@ -146,6 +147,7 @@ main(
         next_module = tmp_next;
     }
 
+    retcode = 0;
 error_exit:
     /* resume the vm */
     vmi_resume_vm(vmi);
@@ -156,5 +158,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -125,8 +125,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -51,6 +51,8 @@ int main (int argc, char **argv)
     struct sigaction act = {0};
     vmi_init_data_t *init_data = NULL;
     vmi_mode_t mode = {0};
+    int retcode = 1;
+
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -63,7 +65,7 @@ int main (int argc, char **argv)
 
     if (argc < 2) {
         fprintf(stderr, "Usage: msr_events_example <name of VM> [socket path]\n");
-        exit(1);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
@@ -116,6 +118,7 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+    retcode = 0;
 error_exit:
     vmi_clear_event(vmi, &msr_event, NULL);
 
@@ -125,5 +128,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -64,7 +64,7 @@ int main (int argc, char **argv)
     char *name = NULL;
 
     if (argc < 2) {
-        fprintf(stderr, "Usage: msr_events_example <name of VM> [socket path]\n");
+        fprintf(stderr, "Usage: %s <name of VM> [socket path]\n", argv[0]);
         return retcode;
     }
 

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -49,8 +49,7 @@ int main (int argc, char **argv)
     vmi_instance_t vmi = {0};
     vmi_event_t msr_event = {0};
     struct sigaction act = {0};
-    vmi_init_data_t *init_data = alloca(sizeof(vmi_init_data_t)
-                                        + (sizeof(vmi_init_data_entry_t) * 1));
+    vmi_init_data_t *init_data = NULL;
     vmi_mode_t mode = {0};
     act.sa_handler = close_handler;
     act.sa_flags = 0;
@@ -74,7 +73,7 @@ int main (int argc, char **argv)
     if (argc == 3) {
         char *path = argv[2];
 
-        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
         init_data->count = 1;
         init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
         init_data->entry[0].data = strdup(path);
@@ -84,13 +83,13 @@ int main (int argc, char **argv)
     if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
                                            init_data, &mode)) {
         fprintf(stderr, "Failed to get access mode\n");
-        exit(1);
+        goto error_exit;
     }
 
     if (VMI_FAILURE ==
             vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, NULL)) {
         fprintf(stderr, "Failed to init LibVMI library.\n");
-        exit(1);
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -122,6 +121,9 @@ error_exit:
 
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -47,6 +47,7 @@ int main (int argc, char **argv)
     uint64_t domid = 0;
     uint8_t init = VMI_INIT_DOMAINNAME, config_type = VMI_CONFIG_GLOBAL_FILE_ENTRY;
     void *input = NULL, *config = NULL;
+    int retcode = 1;
 
     if ( argc < 2 ) {
         printf("Usage: %s\n", argv[0]);
@@ -54,7 +55,7 @@ int main (int argc, char **argv)
         printf("\t -d/--domid <domain id>\n");
         printf("\t -j/--json <path to kernel's json profile>\n");
         printf("\t -s/--socket <path to KVMI socket>\n");
-        return 1;
+        return retcode;
     }
 
     // left for compatibility
@@ -95,7 +96,7 @@ int main (int argc, char **argv)
                     break;
                 default:
                     printf("Unknown option\n");
-                    return 1;
+                    return retcode;
             }
     }
 
@@ -248,6 +249,7 @@ int main (int argc, char **argv)
         }
     };
 
+    retcode = 0;
 error_exit:
     /* resume the vm */
     vmi_resume_vm(vmi);
@@ -258,5 +260,5 @@ error_exit:
     if (init_data)
         free(init_data);
 
-    return 0;
+    return retcode;
 }

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -257,8 +257,10 @@ error_exit:
     /* cleanup any memory associated with the LibVMI instance */
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -36,13 +36,13 @@
 
 int main (int argc, char **argv)
 {
-    vmi_instance_t vmi;
+    vmi_instance_t vmi = {0};
     addr_t list_head = 0, cur_list_entry = 0, next_list_entry = 0;
     addr_t current_process = 0;
     char *procname = NULL;
     vmi_pid_t pid = 0;
     unsigned long tasks_offset = 0, pid_offset = 0, name_offset = 0;
-    status_t status;
+    status_t status = VMI_FAILURE;
     vmi_init_data_t *init_data = NULL;
     uint64_t domid = 0;
     uint8_t init = VMI_INIT_DOMAINNAME, config_type = VMI_CONFIG_GLOBAL_FILE_ENTRY;

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -88,8 +88,7 @@ int main (int argc, char **argv)
                     config = (void*)optarg;
                     break;
                 case 's':
-                    init_data = alloca(sizeof(vmi_init_data_t)
-                                       + (sizeof(vmi_init_data_entry_t) * 1));
+                    init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
                     init_data->count = 1;
                     init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
                     init_data->entry[0].data = strdup(optarg);
@@ -103,7 +102,7 @@ int main (int argc, char **argv)
     /* initialize the libvmi library */
     if (VMI_FAILURE == vmi_init_complete(&vmi, input, init, init_data, config_type, config, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     /* init the offset values */
@@ -255,6 +254,9 @@ error_exit:
 
     /* cleanup any memory associated with the LibVMI instance */
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/singlestep-event-example.c
+++ b/examples/singlestep-event-example.c
@@ -188,8 +188,10 @@ int main (int argc, char **argv)
 error_exit:
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/singlestep-event-example.c
+++ b/examples/singlestep-event-example.c
@@ -32,18 +32,10 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/events.h>
 
-static vmi_event_t single_event = {0};
-static vmi_instance_t vmi = {0};
-
 static int interrupted = 0;
 static void close_handler(int sig)
 {
     interrupted = sig;
-}
-
-void exit_cleanup()
-{
-    vmi_destroy(vmi);
 }
 
 event_response_t single_step_callback(vmi_instance_t vmi, vmi_event_t *event)
@@ -59,17 +51,32 @@ event_response_t single_step_callback(vmi_instance_t vmi, vmi_event_t *event)
 
 int main (int argc, char **argv)
 {
-    struct sigaction act;
+    struct sigaction act = {0};
+    vmi_instance_t vmi = {0};
+    vmi_event_t single_event = {0};
+    vmi_mode_t mode = {0};
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
 
     char *name = NULL;
 
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <name of VM> \n", argv[0]);
-        exit(1);
+        fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
     name = argv[1];
+
+    // KVMi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
 
     /* for a clean exit */
     act.sa_handler = close_handler;
@@ -80,15 +87,19 @@ int main (int argc, char **argv)
     sigaction(SIGINT,  &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
+    /* get access mode */
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, &mode)) {
+        fprintf(stderr, "Failed to get access mode\n");
+        goto error_exit;
+    }
+
     /* initialize the libvmi library */
-    if (VMI_FAILURE == vmi_init(&vmi, VMI_XEN, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, NULL, NULL)) {
+    if (VMI_FAILURE == vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
-    // register cleanup routine
-    atexit(&exit_cleanup);
 
     // get number of vcpus
     unsigned int num_vcpus = vmi_get_num_vcpus(vmi);
@@ -104,7 +115,7 @@ int main (int argc, char **argv)
     // register
     if (VMI_FAILURE == vmi_register_event(vmi, &single_event)) {
         fprintf(stderr, "Failed to register singlestep event\n");
-        return 1;
+        goto error_exit;
     }
 
     // event loop
@@ -112,7 +123,7 @@ int main (int argc, char **argv)
         printf("Waiting for events...\n");
         if (VMI_FAILURE == vmi_events_listen(vmi,500)) {
             fprintf(stderr, "Failed to listen on events\n");
-            return 1;
+            goto error_exit;
         }
     }
 
@@ -122,25 +133,25 @@ int main (int argc, char **argv)
     // this prevents new events from being queued
     if (VMI_FAILURE == vmi_pause_vm(vmi)) {
         fprintf(stderr, "Failed to pause VM\n");
-        return 1;
+        goto error_exit;
     }
     // clean event ring
     if (VMI_FAILURE == vmi_events_listen(vmi, 0)) {
         fprintf(stderr, "Failed to pause VM\n");
-        return 1;
+        goto error_exit;
     }
 
     // disable singlestep on all vcpus
     for (unsigned int vcpu=0; vcpu < num_vcpus; vcpu++) {
         if (VMI_FAILURE == vmi_toggle_single_step_vcpu(vmi, &single_event, vcpu, false)) {
             fprintf(stderr, "Failed to stop singlestepping on VCPU %d\n", vcpu);
-            return 1;
+            goto error_exit;
         }
     }
     printf("Singlestep stopped\n");
     if (VMI_FAILURE == vmi_resume_vm(vmi)) {
         fprintf(stderr, "Failed to resume VM\n");
-        return 1;
+        goto error_exit;
     }
 
     // VM should be running
@@ -150,31 +161,35 @@ int main (int argc, char **argv)
     // pause before changing VM state
     if (VMI_FAILURE == vmi_pause_vm(vmi)) {
         fprintf(stderr, "Failed to pause VM\n");
-        return 1;
+        goto error_exit;
     }
     printf("Restarting singlestep\n");
     for (unsigned int vcpu=0; vcpu < num_vcpus; vcpu++) {
         if (VMI_FAILURE == vmi_toggle_single_step_vcpu(vmi, &single_event, vcpu, true)) {
             fprintf(stderr, "Failed to enable singlestep on VCPU %d\n", vcpu);
-            return 1;
+            goto error_exit;
         }
     }
     if (VMI_FAILURE == vmi_resume_vm(vmi)) {
         fprintf(stderr, "Failed to resume VM\n");
-        return 1;
+        goto error_exit;
     }
     // process a few more singlestep events
     for (int i=0; i < 5; i++) {
         printf("Waiting for events...\n");
         if (VMI_FAILURE == vmi_events_listen(vmi,500)) {
             fprintf(stderr, "Failed to listen on events\n");
-            return 1;
+            goto error_exit;
         }
     }
     printf("Finished with test.\n");
 
-    // singlestep event will be cleared by vmi_destroy(), called
-    // by exit_cleanup() routine configured earlier upon exit
+    retcode = 0;
+error_exit:
+    vmi_destroy(vmi);
 
-    return 0;
+    if (init_data)
+        free(init_data);
+
+    return retcode;
 }

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -212,8 +212,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -121,23 +121,35 @@ event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event)
 
 int main (int argc, char **argv)
 {
-    vmi_instance_t vmi = NULL;
+    vmi_instance_t vmi = {0};
     status_t status = VMI_SUCCESS;
+    vmi_init_data_t *init_data = NULL;
     addr_t gfn;
+    int retcode = 1;
 
     struct sigaction act;
 
-    mm_enabled=0;
+    mm_enabled = 0;
 
     char *name = NULL;
 
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <name of VM>\n", argv[0]);
-        exit(1);
+        fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
     name = argv[1];
+
+    // KVMi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
 
     /* for a clean exit */
     act.sa_handler = close_handler;
@@ -151,9 +163,9 @@ int main (int argc, char **argv)
     // Initialize the libvmi library.
     if (VMI_FAILURE ==
             vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
-                              NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+                              init_data, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -195,8 +207,13 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+    retcode = 0;
+error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    return 0;
+    if (init_data)
+        free(init_data);
+
+    return retcode;
 }

--- a/examples/va-pages.c
+++ b/examples/va-pages.c
@@ -155,8 +155,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return 0;
 }

--- a/examples/va-pages.c
+++ b/examples/va-pages.c
@@ -86,21 +86,32 @@ event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event)
 
 int main (int argc, char **argv)
 {
-    vmi_instance_t vmi = NULL;
+    vmi_instance_t vmi = {0};
     status_t status = VMI_SUCCESS;
-
     struct sigaction act;
+    int retcode = 1;
+    vmi_init_data_t *init_data = NULL;
 
     char *name = NULL;
     va_pages = NULL;
 
     if (argc < 2) {
-        fprintf(stderr, "Usage: events_example <name of VM>\n");
-        exit(1);
+        fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
+        return retcode;
     }
 
     // Arg 1 is the VM name.
     name = argv[1];
+
+    // KVMi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
 
     /* for a clean exit */
     act.sa_handler = close_handler;
@@ -114,9 +125,9 @@ int main (int argc, char **argv)
     // Initialize the libvmi library.
     if (VMI_FAILURE ==
             vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
-                              NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+                              init_data, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -139,8 +150,13 @@ int main (int argc, char **argv)
     printf("Finished with test.\n");
 
     free_va_pages();
+    retcode = 0;
+error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
+
+    if (init_data)
+        free(init_data);
 
     return 0;
 }

--- a/examples/wait-for-domain-example.c
+++ b/examples/wait-for-domain-example.c
@@ -43,10 +43,22 @@ event_response_t wait_for_domain(__attribute__((unused)) vmi_instance_t vmi, vmi
     return 1;
 }
 
-int main ()
+int main (int argc, char **argv)
 {
-    vmi_instance_t vmi;
+    vmi_instance_t vmi = {0};
+    vmi_mode_t mode = {0};
     struct sigaction act;
+    vmi_init_data_t *init_data = NULL;
+    char *name = NULL;
+    int retcode = 1;
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <name of VM> [<socket>]\n", argv[0]);
+        return retcode;
+    }
+
+    name = argv[1];
+
     act.sa_handler = close_handler;
     act.sa_flags = 0;
     sigemptyset(&act.sa_mask);
@@ -55,11 +67,26 @@ int main ()
     sigaction(SIGINT,  &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    // Initialize the libvmi library.
-    if (VMI_FAILURE ==
-            vmi_init(&vmi, VMI_XEN, NULL, VMI_INIT_DOMAINWATCH, NULL, NULL)) {
+    // KVMi socket ?
+    if (argc == 3) {
+        char *path = argv[2];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
+    /* get access mode */
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, &mode)) {
+        fprintf(stderr, "Failed to get access mode\n");
+        goto error_exit;
+    }
+
+    /* initialize the libvmi library */
+    if (VMI_FAILURE == vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, init_data, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -78,8 +105,13 @@ int main ()
 
     printf("Finished with test.\n");
 
+    retcode = 0;
+error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    return 0;
+    if (init_data)
+        free(init_data);
+
+    return retcode;
 }

--- a/examples/wait-for-domain-example.c
+++ b/examples/wait-for-domain-example.c
@@ -110,8 +110,10 @@ error_exit:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/win-guid.c
+++ b/examples/win-guid.c
@@ -344,12 +344,14 @@ void print_pe_header(vmi_instance_t vmi, addr_t image_base_p, uint8_t *pe)
 int main(int argc, char **argv)
 {
 
-    vmi_instance_t vmi = NULL;
-    vmi_mode_t mode;
+    vmi_instance_t vmi = {0};
+    vmi_mode_t mode = {0};
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
 
     /* this is the VM that we are looking at */
-    if (argc != 3) {
-        printf("Usage: %s name|domid <domain name|domain id>\n", argv[0]);
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s name|domid <domain name|domain id> [<socket>]\n", argv[0]);
         return 1;
     }   // if
 
@@ -369,13 +371,23 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    if (VMI_FAILURE == vmi_get_access_mode(vmi, domain, init_flags, NULL, &mode) )
-        return 1;
+    // KVMi socket ?
+    if (argc == 4) {
+        char *path = argv[3];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
+    if (VMI_FAILURE == vmi_get_access_mode(vmi, domain, init_flags, init_data, &mode) )
+        goto error_exit;
 
     /* initialize the libvmi library */
-    if (VMI_FAILURE == vmi_init(&vmi, mode, domain, init_flags, NULL, NULL)) {
+    if (VMI_FAILURE == vmi_init(&vmi, mode, domain, init_flags, init_data, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto error_exit;
     }
 
     max_mem = vmi_get_max_physical_address(vmi);
@@ -403,9 +415,14 @@ int main(int argc, char **argv)
         }
     }
 
+    if (found)
+        retcode = 0;
+error_exit:
     /* cleanup any memory associated with the LibVMI instance */
     vmi_destroy(vmi);
 
-    if (found) return 0;
-    return 1;
+    if (init_data)
+        free(init_data);
+
+    return retcode;
 }

--- a/examples/win-guid.c
+++ b/examples/win-guid.c
@@ -421,8 +421,10 @@ error_exit:
     /* cleanup any memory associated with the LibVMI instance */
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return retcode;
 }

--- a/examples/win-offsets.c
+++ b/examples/win-offsets.c
@@ -217,8 +217,10 @@ done:
     if (config)
         g_hash_table_destroy(config);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return rc;
 }

--- a/examples/win-offsets.c
+++ b/examples/win-offsets.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 {
     GHashTable* config = NULL;
     vmi_instance_t vmi = NULL;
-    vmi_mode_t mode;
+    vmi_mode_t mode = {0};
     uint64_t init_flags = 0;
     vmi_init_data_t *init_data = NULL;
     uint64_t domid = 0;

--- a/examples/xen-emulate-response.c
+++ b/examples/xen-emulate-response.c
@@ -60,16 +60,28 @@ int main (int argc, char **argv)
     status_t status = VMI_SUCCESS;
     addr_t addr;
     char *name = NULL;
+    vmi_init_data_t *init_data = NULL;
     struct sigaction act;
+    int rc = 1;
 
     if (argc < 3) {
-        fprintf(stderr, "Usage: xen-emulate-response <name of VM> <kernel virtual address trap in hex>\n");
-        return 1;
+        fprintf(stderr, "Usage: %s <name of VM> <kernel virtual address trap in hex> [<socket>]\n", argv[0]);
+        return rc;
     }
 
     // Arg 1 is the VM name.
     name = argv[1];
     addr = (addr_t) strtoul(argv[2], NULL, 16);
+
+    // KVMi socket ?
+    if (argc == 4) {
+        char *path = argv[3];
+
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
 
     /* for a clean exit */
     act.sa_handler = close_handler;
@@ -83,9 +95,9 @@ int main (int argc, char **argv)
     // Initialize the libvmi library.
     if (VMI_FAILURE ==
             vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
-                              NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
+                              init_data, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
         printf("Failed to init LibVMI library.\n");
-        return 1;
+        goto leave;
     }
 
     printf("LibVMI init succeeded!\n");
@@ -113,9 +125,13 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
+    rc = 0;
 leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    return 0;
+    if (init_data)
+        free(init_data);
+
+    return rc;
 }

--- a/examples/xen-emulate-response.c
+++ b/examples/xen-emulate-response.c
@@ -56,12 +56,12 @@ event_response_t cb(vmi_instance_t vmi, vmi_event_t *event)
 int main (int argc, char **argv)
 {
     vmi_instance_t vmi = NULL;
-    vmi_event_t event;
+    vmi_event_t event = {0};
     status_t status = VMI_SUCCESS;
-    addr_t addr;
+    addr_t addr = 0;
     char *name = NULL;
     vmi_init_data_t *init_data = NULL;
-    struct sigaction act;
+    struct sigaction act = {0};
     int rc = 1;
 
     if (argc < 3) {

--- a/examples/xen-emulate-response.c
+++ b/examples/xen-emulate-response.c
@@ -130,8 +130,10 @@ leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
-    if (init_data)
+    if (init_data) {
+        free(init_data->entry[0].data);
         free(init_data);
+    }
 
     return rc;
 }

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -803,14 +803,18 @@ vmi_init_complete(
         if ( error )
             *error = VMI_INIT_ERROR_PAGING;
 
-        return VMI_FAILURE;
+        goto error_exit;
     }
 
     if ( VMI_OS_UNKNOWN == vmi_init_os(_vmi, config_mode, config, error) )
-        return VMI_FAILURE;
+        goto error_exit;
 
     *vmi = _vmi;
     return VMI_SUCCESS;
+error_exit:
+    if (_vmi)
+        g_free(_vmi);
+    return VMI_FAILURE;
 }
 
 status_t

--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -33,7 +33,6 @@ This section will give an implementation status of the LibVMI API on the new KVM
             - [x] CR
             - [ ] MSR
                 - [ ] `MSR_ALL` (loop over all defined MSRs in LibVMI. Unable to set intercept on any kind of MSR in `KVMi-v6`)
-                - [ ] `MSR_HYPERVISOR` (not supported in `KVMi-v6`)
         - [ ] `reg_event.equal`
         - [ ] `reg_event.async`
         - [ ] `reg_event.onchange`

--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -71,6 +71,11 @@ This section will give an implementation status of the LibVMI API on the new KVM
     - [ ] cpuid
     - [ ] privcall
     - [ ] descriptor
+        - [ ] `desc_event.instr_info`
+        - [ ] `desc_event.exit_qualification`
+        - [ ] `desc_event.exit_info`
+        - [x] `desc_event.descriptor`
+        - [x] `desc_event.is_write`
 - [ ] VMI Event response
     - [x] `VMI_EVENT_RESPONSE_NONE`
     - [ ] `VMI_EVENT_RESPONSE_EMULATE`

--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -1,0 +1,73 @@
+# KVM Driver
+
+## Overview
+
+The actual KVM driver contains 2 implementations
+
+- KVMi: the new [KVM virtual machine introspection API](https://static.sched.com/hosted_files/kvmforum2019/f6/Advanced%20VMI%20on%20KVM%3A%20A%20progress%20Report.pdf)
+- Legacy: the legacy KVM driver for LibVMI, using either `GDB` or the `fast-memaccess` patches available in `libvmi/tools/qemu-kvm-patch`
+
+## LibVMI API Implementation
+
+This section will give an implementation status of the LibVMI API on the new KVM driver.
+
+- [x] r/w physical memory
+- [ ] VCPU registers (x86 only)
+    - [ ] read
+        - only essential MSRs are retrieved
+        - `DR6`/`DR7` not available in libkvmi
+    - [ ] write
+        - only general purpose registers
+- [x] memory size
+- [x] pause / resume
+- [x] request page fault
+- [ ] guest memory mapping
+- [ ] TSC info
+- [ ] MTRR
+- [ ] XSAVE
+- [ ] SLAT
+- [ ] VMI Events
+    - [ ] singlestep (not supported in `KVMi-v6`)
+    - [ ] register access
+        - [ ] `reg_event.reg`
+            - [x] CR
+            - [ ] MSR
+                - [ ] `MSR_ALL` (loop over all defined MSRs in LibVMI. Unable to set intercept on any kind of MSR in `KVMi-v6`)
+                - [ ] `MSR_HYPERVISOR` (not supported in `KVMi-v6`)
+        - [ ] `reg_event.equal`
+        - [ ] `reg_event.async`
+        - [ ] `reg_event.onchange`
+        - [ ] `reg_event.in_access`
+            - [x] `VMI_REGACCESS_N`
+            - [x] `VMI_REGACCESS_W`
+            - [ ] `VMI_REGACCESS_R` (not available in `KVMi-v6`)
+            - [ ] `VMI_REGACCESS_RW` (not available in `KVMi-v6`)
+        - [ ] `reg_event.out_access`
+        - [x] `reg_event.value`
+        - [x] `reg_event.previous`
+        - [x] `reg_event.msr`
+    - [ ] interrupt
+        - [ ] `interrupt_event.intr`
+            - [x] `INT3`
+            - [ ] `INT_NEXT`
+        - [ ] `interrupt_event.insn_length`
+        - [x] `interrupt_event.reinject`
+        - [ ] `interrupt_event.vector`
+        - [ ] `interrupt_event.type`
+        - [ ] `interrupt_event.error_code`
+        - [x] `interrupt_event.cr2`
+        - [x] `interrupt_event.gla`
+        - [x] `interrupt_event.gfn`
+        - [x] `interrupt_event.offset`
+    - [ ] memory access
+        - [x] `mem_event.gfn`
+        - [x] `mem_event.generic`
+        - [x] `mem_event.in_access`
+        - [x] `mem_event.out_access`
+        - [ ] `mem_event.gptw`
+        - [ ] `mem_event.gla_valid`
+        - [x] `mem_event.gla`
+        - [x] `mem_event.offset`
+    - [ ] cpuid
+    - [ ] privcall
+    - [ ] descriptor

--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -71,3 +71,15 @@ This section will give an implementation status of the LibVMI API on the new KVM
     - [ ] cpuid
     - [ ] privcall
     - [ ] descriptor
+- [ ] VMI Event response
+    - [x] `VMI_EVENT_RESPONSE_NONE`
+    - [ ] `VMI_EVENT_RESPONSE_EMULATE`
+    - [ ] `VMI_EVENT_RESPONSE_EMULATE_NOWRITE`
+    - [x] `VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA` (only for memory access events)
+    - [ ] `VMI_EVENT_RESPONSE_DENY`
+    - [ ] `VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP`
+    - [ ] `VMI_EVENT_RESPONSE_SLAT_ID`
+    - [ ] `VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID`
+    - [x] `VMI_EVENT_RESPONSE_SET_REGISTERS`
+    - [ ] `VMI_EVENT_RESPONSE_SET_EMUL_INSN`
+    - [ ] `VMI_EVENT_RESPONSE_GET_NEXT_INTERRUPT`

--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -23,6 +23,10 @@ This section will give an implementation status of the LibVMI API on the new KVM
 - [x] request page fault
 - [ ] guest memory mapping
 - [ ] TSC info
+  - [ ] `tsc_mode`
+  - [ ] `elapsed_nsec`
+  - [x] `gtsc_khz`
+  - [ ] `incarnation`
 - [ ] MTRR
 - [ ] XSAVE
 - [ ] SLAT

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -254,8 +254,12 @@ get_kvmi_registers(
         return false;
 
     msrs.msrs.nmsrs = sizeof(msrs.entries)/sizeof(msrs.entries[0]);
-    msrs.entries[0].index = msr_index[MSR_EFER];
-    msrs.entries[1].index = msr_index[MSR_STAR];
+    msrs.entries[0].index = msr_index[MSR_IA32_SYSENTER_CS];
+    msrs.entries[1].index = msr_index[MSR_IA32_SYSENTER_ESP];
+    msrs.entries[2].index = msr_index[MSR_IA32_SYSENTER_EIP];
+    msrs.entries[3].index = msr_index[MSR_EFER];
+    msrs.entries[4].index = msr_index[MSR_STAR];
+    msrs.entries[5].index = msr_index[MSR_LSTAR];
 
     err = kvm->libkvmi.kvmi_get_registers(kvm->kvmi_dom, vcpu, &regs, &sregs, &msrs.msrs, &mode);
 
@@ -337,11 +341,23 @@ get_kvmi_registers(
         case GS_BASE:
             *value = sregs.gs.base;
             break;
-        case MSR_EFER:
+        case MSR_IA32_SYSENTER_CS:
             *value = msrs.entries[0].data;
             break;
-        case MSR_STAR:
+        case MSR_IA32_SYSENTER_ESP:
             *value = msrs.entries[1].data;
+            break;
+        case MSR_IA32_SYSENTER_EIP:
+            *value = msrs.entries[2].data;
+            break;
+        case MSR_EFER:
+            *value = msrs.entries[3].data;
+            break;
+        case MSR_STAR:
+            *value = msrs.entries[4].data;
+            break;
+        case MSR_LSTAR:
+            *value = msrs.entries[5].data;
             break;
         default:
             dbprint(VMI_DEBUG_KVM, "--Reading register %"PRIu64" not implemented\n", reg);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -84,6 +84,67 @@ reply_continue(kvm_instance_t *kvm, struct kvmi_dom_event *ev)
     return VMI_SUCCESS;
 }
 
+
+void
+kvmi_regs_to_libvmi(
+    struct kvm_regs *kvmi_regs,
+    struct kvm_sregs *kvmi_sregs,
+    x86_registers_t *libvmi_regs)
+{
+    x86_registers_t x86_regs = {0};
+    //      standard regs
+    x86_regs.rax = kvmi_regs->rax;
+    x86_regs.rbx = kvmi_regs->rbx;
+    x86_regs.rcx = kvmi_regs->rcx;
+    x86_regs.rdx = kvmi_regs->rdx;
+    x86_regs.rsi = kvmi_regs->rsi;
+    x86_regs.rdi = kvmi_regs->rdi;
+    x86_regs.rip = kvmi_regs->rip;
+    x86_regs.rsp = kvmi_regs->rsp;
+    x86_regs.rbp = kvmi_regs->rbp;
+    x86_regs.rflags = kvmi_regs->rflags;
+    x86_regs.r8 = kvmi_regs->r8;
+    x86_regs.r9 = kvmi_regs->r9;
+    x86_regs.r10 = kvmi_regs->r10;
+    x86_regs.r11 = kvmi_regs->r11;
+    x86_regs.r12 = kvmi_regs->r12;
+    x86_regs.r13 = kvmi_regs->r13;
+    x86_regs.r14 = kvmi_regs->r14;
+    x86_regs.r15 = kvmi_regs->r15;
+    //      special regs
+    //          Control Registers
+    x86_regs.cr0 = kvmi_sregs->cr0;
+    x86_regs.cr2 = kvmi_sregs->cr2;
+    x86_regs.cr3 = kvmi_sregs->cr3;
+    x86_regs.cr4 = kvmi_sregs->cr4;
+    //          CS
+    x86_regs.cs_base = kvmi_sregs->cs.base;
+    x86_regs.cs_limit = kvmi_sregs->cs.limit;
+    x86_regs.cs_sel = kvmi_sregs->cs.selector;
+    //          DS
+    x86_regs.ds_base = kvmi_sregs->ds.base;
+    x86_regs.ds_limit = kvmi_sregs->ds.limit;
+    x86_regs.ds_sel = kvmi_sregs->ds.selector;
+    //          SS
+    x86_regs.ss_base = kvmi_sregs->ss.base;
+    x86_regs.ss_limit = kvmi_sregs->ss.limit;
+    x86_regs.ss_sel = kvmi_sregs->ss.selector;
+    //          ES
+    x86_regs.es_base = kvmi_sregs->es.base;
+    x86_regs.es_limit = kvmi_sregs->es.limit;
+    x86_regs.es_sel = kvmi_sregs->es.selector;
+    //          FS
+    x86_regs.fs_base = kvmi_sregs->fs.base;
+    x86_regs.fs_limit = kvmi_sregs->fs.limit;
+    x86_regs.fs_sel = kvmi_sregs->fs.selector;
+    //          GS
+    x86_regs.gs_base = kvmi_sregs->gs.base;
+    x86_regs.gs_limit = kvmi_sregs->gs.limit;
+    x86_regs.gs_sel = kvmi_sregs->gs.selector;
+    // assign
+    (*libvmi_regs) = x86_regs;
+}
+
 void *
 kvm_get_memory_patch(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -484,6 +484,7 @@ kvm_destroy(
 
     dlclose(kvm->libkvmi.handle);
     dlclose(kvm->libvirt.handle);
+    dlclose(kvm->libvirt.handle_qemu);
     g_free(kvm);
 
 }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -174,7 +174,7 @@ kvm_setup_live_mode(
 // KVMI-Specific Interface Functions (no direction mapping to driver_*)
 
 static int
-cb_new_guest(
+new_guest_cb(
     void *dom,
     unsigned char (*uuid)[16],
     void *ctx)
@@ -276,7 +276,7 @@ init_kvmi(
     kvm->kvmi_dom = NULL;
 
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
-    kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, cb_new_guest, handshake_cb, kvm);
+    kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, new_guest_cb, handshake_cb, kvm);
     if (kvm->kvmi) {
         struct timeval now;
         if (gettimeofday(&now, NULL) == 0) {

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -217,6 +217,18 @@ cb_new_guest(
     return 0;
 }
 
+static int handshake_cb(
+    const struct kvmi_qemu2introspector *qemu,
+    struct kvmi_introspector2qemu *intro,
+    void *ctx)
+{
+    (void)qemu;
+    (void)intro;
+    (void)ctx;
+    dbprint(VMI_DEBUG_KVM, "--KVMi handshake\n");
+    return 0;
+}
+
 static bool
 init_kvmi(
     kvm_instance_t *kvm,
@@ -229,7 +241,7 @@ init_kvmi(
     kvm->kvmi_dom = NULL;
 
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
-    kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, cb_new_guest, NULL, kvm);
+    kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, cb_new_guest, handshake_cb, kvm);
     if (kvm->kvmi) {
         struct timeval now;
         if (gettimeofday(&now, NULL) == 0) {

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -238,7 +238,8 @@ static bool
 get_kvmi_registers(
     kvm_instance_t *kvm,
     reg_t reg,
-    uint64_t *value)
+    uint64_t *value,
+    unsigned short vcpu)
 {
     struct kvm_regs regs;
     struct kvm_sregs sregs;
@@ -247,7 +248,6 @@ get_kvmi_registers(
         struct kvm_msr_entry entries[6];
     } msrs = {0};
     unsigned int mode;
-    unsigned short vcpu = 0;
     int err;
 
     if (!kvm->kvmi_dom)
@@ -778,11 +778,11 @@ kvm_get_vcpureg(
     vmi_instance_t vmi,
     uint64_t *value,
     reg_t reg,
-    unsigned long UNUSED(vcpu))
+    unsigned long vcpu)
 {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
 
-    if (get_kvmi_registers(kvm, reg, value))
+    if (get_kvmi_registers(kvm, reg, value, (unsigned short)vcpu))
         return VMI_SUCCESS;
 
     return VMI_FAILURE;

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -212,7 +212,8 @@ cb_new_guest(
      * If kvmi_dom is not NULL it means this is a reconnection.
      * The previous connection was closed somehow.
      */
-    kvm->libkvmi.kvmi_domain_close(kvm->kvmi_dom, true);
+    if (kvm->kvmi_dom)
+        kvm->libkvmi.kvmi_domain_close(kvm->kvmi_dom, true);
     kvm->kvmi_dom = dom;
     pthread_cond_signal(&kvm->kvm_start_cond);
     pthread_mutex_unlock(&kvm->kvm_connect_mutex);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -239,6 +239,31 @@ static int handshake_cb(
     return 0;
 }
 
+static void
+log_cb(
+    kvmi_log_level level,
+    const char *s,
+    void *ctx)
+{
+    (void)ctx;
+    switch (level) {
+        case KVMI_LOG_LEVEL_ERROR:
+            dbprint(VMI_DEBUG_KVM, "--KVMi Error: %s\n", s);
+            break;
+        case KVMI_LOG_LEVEL_WARNING:
+            dbprint(VMI_DEBUG_KVM, "--KVMi Warning: %s\n", s);
+            break;
+        case KVMI_LOG_LEVEL_INFO:
+            dbprint(VMI_DEBUG_KVM, "--KVMi Info: %s\n", s);
+            break;
+        case KVMI_LOG_LEVEL_DEBUG:
+            dbprint(VMI_DEBUG_KVM, "--KVMi Debug: %s\n", s);
+            break;
+        default:
+            errprint("Unhandled KVMi log level %d\n", level);
+    }
+}
+
 static bool
 init_kvmi(
     kvm_instance_t *kvm,
@@ -528,6 +553,9 @@ kvm_init_vmi(
     dbprint(VMI_DEBUG_KVM, "--libvirt version %lu\n", libVer);
 
     vmi->vm_type = NORMAL;
+
+    // configure log cb before connecting
+    kvm->libkvmi.kvmi_set_log_cb(log_cb, (void*)vmi);
 
     dbprint(VMI_DEBUG_KVM, "--Connecting to KVMI...\n");
     if (!init_kvmi(kvm,  socket_path)) {

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -712,6 +712,21 @@ status_t kvm_request_page_fault (
 }
 
 status_t
+kvm_get_vcpureg(
+    vmi_instance_t vmi,
+    uint64_t *value,
+    reg_t reg,
+    unsigned long vcpu)
+{
+    kvm_instance_t *kvm = kvm_get_instance(vmi);
+
+    if (get_kvmi_registers(kvm, reg, value, (unsigned short)vcpu))
+        return VMI_SUCCESS;
+
+    return VMI_FAILURE;
+}
+
+status_t
 kvm_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *registers,
@@ -874,21 +889,6 @@ kvm_set_vcpuregs(vmi_instance_t vmi,
         return VMI_FAILURE;
     }
     return VMI_SUCCESS;
-}
-
-status_t
-kvm_get_vcpureg(
-    vmi_instance_t vmi,
-    uint64_t *value,
-    reg_t reg,
-    unsigned long vcpu)
-{
-    kvm_instance_t *kvm = kvm_get_instance(vmi);
-
-    if (get_kvmi_registers(kvm, reg, value, (unsigned short)vcpu))
-        return VMI_SUCCESS;
-
-    return VMI_FAILURE;
 }
 
 status_t

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -205,8 +205,14 @@ cb_new_guest(
     uuid_str[current_size] = '\0';
     // get fd
     int fd = kvm->libkvmi.kvmi_connection_fd(dom);
+    // get version
+    unsigned int version = 0;
+    if (kvm->libkvmi.kvmi_get_version(dom, &version) != 0) {
+        errprint("Failed to get KVMi version\n");
+        return 1;
+    }
     // print infos
-    dbprint(VMI_DEBUG_KVM, "--KVMi new guest - UUID: %s, FD: %d\n", uuid_str, fd);
+    dbprint(VMI_DEBUG_KVM, "--KVMi new guest - UUID: %s, FD: %d, protocol version: %d\n", uuid_str, fd, version);
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
     /*
      * If kvmi_dom is not NULL it means this is a reconnection.

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -244,7 +244,7 @@ get_kvmi_registers(
     struct kvm_sregs sregs;
     struct {
         struct kvm_msrs      msrs;
-        struct kvm_msr_entry entries[2];
+        struct kvm_msr_entry entries[6];
     } msrs = {0};
     unsigned int mode;
     unsigned short vcpu = 0;

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -578,6 +578,45 @@ status_t kvm_request_page_fault (
     return VMI_SUCCESS;
 }
 
+status_t kvm_get_tsc_info(
+    vmi_instance_t vmi,
+    __attribute__((unused)) uint32_t *tsc_mode,
+    __attribute__((unused)) uint64_t *elapsed_nsec,
+    uint32_t *gtsc_khz,
+    __attribute__((unused)) uint32_t *incarnation)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi) {
+        errprint("Invalid vmi handle\n");
+        return VMI_FAILURE;
+    }
+#endif
+    // checking only gtsc_khz parameter
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!gtsc_khz) {
+        errprint("Invalid gtsc_khz pointer\n");
+        return VMI_FAILURE;
+    }
+#endif
+    kvm_instance_t *kvm = kvm_get_instance(vmi);
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!kvm || !kvm->kvmi_dom) {
+        errprint("Invalid kvm/kvmi handles\n");
+        return VMI_FAILURE;
+    }
+#endif
+    dbprint(VMI_DEBUG_KVM, "--Get TSC info\n");
+
+    unsigned long long speed = 0;
+    if (kvm->libkvmi.kvmi_get_tsc_speed(kvm->kvmi_dom, &speed))
+        return VMI_FAILURE;
+
+    // convert to KHz and assign gtsc_khz
+    (*gtsc_khz) = speed / 1000;
+
+    return VMI_SUCCESS;
+}
+
 status_t
 kvm_get_vcpureg(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -203,7 +203,10 @@ cb_new_guest(
         }
     }
     uuid_str[current_size] = '\0';
-    dbprint(VMI_DEBUG_KVM, "--KVMi new guest: UUID: %s\n", uuid_str);
+    // get fd
+    int fd = kvm->libkvmi.kvmi_connection_fd(dom);
+    // print infos
+    dbprint(VMI_DEBUG_KVM, "--KVMi new guest - UUID: %s, FD: %d\n", uuid_str, fd);
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
     /*
      * If kvmi_dom is not NULL it means this is a reconnection.

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -266,6 +266,7 @@ new_guest_cb(
     uuid_str[current_size] = '\0';
     // get fd
     int fd = kvm->libkvmi.kvmi_connection_fd(dom);
+
     // get version
     unsigned int version = 0;
     if (kvm->libkvmi.kvmi_get_version(dom, &version) != 0) {
@@ -273,6 +274,8 @@ new_guest_cb(
         return 1;
     }
     // print infos
+    // silence unused variables if no debug
+    (void)fd;
     dbprint(VMI_DEBUG_KVM, "--KVMi new guest - UUID: %s, FD: %d, protocol version: %d\n", uuid_str, fd, version);
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
     /*
@@ -307,6 +310,7 @@ log_cb(
     void *ctx)
 {
     (void)ctx;
+    (void)s;
     switch (level) {
         case KVMI_LOG_LEVEL_ERROR:
             dbprint(VMI_DEBUG_KVM, "--KVMi Error: %s\n", s);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -521,6 +521,7 @@ kvm_destroy(
     vmi_instance_t vmi)
 {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
+    dbprint(VMI_DEBUG_KVM, "--Destroying KVM driver\n");
 
     kvm_close_vmi(vmi, kvm);
 

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -54,6 +54,9 @@
 #include "driver/kvm/kvm_private.h"
 #include "driver/kvm/kvm_events.h"
 
+// 2 chars for each hex + 1 space + 1 \0
+#define UUID_HEX_STR_LEN (16 * 3 + 1)
+
 enum segment_type {
     SEGMENT_SELECTOR,
     SEGMENT_BASE,
@@ -246,10 +249,8 @@ new_guest_cb(
     }
 
     kvm_instance_t *kvm = ctx;
-    // 2 chars for hex + 1 space
-    unsigned int uuid_str_len = (sizeof(*uuid) * 3) + 1;
-    char uuid_str[uuid_str_len];
-    memset(uuid_str, 0, uuid_str_len);
+    char uuid_str[UUID_HEX_STR_LEN] = {0};
+    memset(uuid_str, 0, UUID_HEX_STR_LEN);
 
     // convert UUID hex to string
     unsigned int current_size = 0;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -32,73 +32,95 @@ status_t kvm_init(
     vmi_instance_t vmi,
     uint32_t init_flags,
     vmi_init_data_t *init_data);
+
 status_t kvm_init_vmi(
     vmi_instance_t vmi,
     uint32_t init_flags,
     vmi_init_data_t *init_data);
+
 void kvm_destroy(
     vmi_instance_t vmi);
 uint64_t kvm_get_id_from_name(
     vmi_instance_t vmi,
     const char *name);
+
 status_t kvm_get_name_from_id(
     vmi_instance_t vmi,
     uint64_t domainid,
     char **name);
+
 uint64_t kvm_get_id(
     vmi_instance_t vmi);
+
 void kvm_set_id(
     vmi_instance_t vmi,
     uint64_t domainid);
+
 status_t kvm_check_id(
     vmi_instance_t vmi,
     uint64_t domainid);
+
 status_t kvm_write(
     vmi_instance_t vmi,
     addr_t paddr,
     void *buf,
     uint32_t length);
+
 status_t kvm_get_name(
     vmi_instance_t vmi,
     char **name);
+
 void kvm_set_name(
     vmi_instance_t vmi,
     const char *name);
+
 status_t kvm_get_memsize(
     vmi_instance_t vmi,
     uint64_t *allocate_ram_size,
     addr_t *maximum_physical_address);
-status_t kvm_request_page_fault (
+
+status_t kvm_request_page_fault(
     vmi_instance_t vmi,
     unsigned long vcpu,
     uint64_t virtual_address,
     uint32_t error_code);
-status_t kvm_get_vcpureg(
-    vmi_instance_t vmi,
-    uint64_t *value,
-    reg_t reg,
-    unsigned long vcpu);
+
 addr_t kvm_pfn_to_mfn(
     vmi_instance_t vmi,
     addr_t pfn);
+
 void *kvm_read_page(
     vmi_instance_t vmi,
     addr_t page);
+
 int kvm_is_pv(
     vmi_instance_t vmi);
+
 status_t kvm_test(
     uint64_t domainid,
     const char *name,
     uint64_t init_flags,
     vmi_init_data_t* init_data);
+
+// pause & resume
 status_t kvm_pause_vm(
     vmi_instance_t vmi);
+
 status_t kvm_resume_vm(
     vmi_instance_t vmi);
+
+// registers
+status_t kvm_get_vcpureg(
+    vmi_instance_t vmi,
+    uint64_t *value,
+    reg_t reg,
+    unsigned long vcpu);
+
 status_t kvm_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
     unsigned long vcpu);
+
 status_t kvm_set_vcpureg(
     vmi_instance_t vmi,
     uint64_t value,

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -85,6 +85,13 @@ status_t kvm_request_page_fault(
     uint64_t virtual_address,
     uint32_t error_code);
 
+status_t kvm_get_tsc_info(
+    vmi_instance_t vmi,
+    uint32_t *tsc_mode,
+    uint64_t *elapsed_nsec,
+    uint32_t *gtsc_khz,
+    uint32_t *incarnation);
+
 addr_t kvm_pfn_to_mfn(
     vmi_instance_t vmi,
     addr_t pfn);
@@ -150,6 +157,7 @@ driver_kvm_setup(vmi_instance_t vmi)
     driver.get_memsize_ptr = &kvm_get_memsize;
 # ifndef ENABLE_KVM_LEGACY
     driver.request_page_fault_ptr = &kvm_request_page_fault;
+    driver.get_tsc_info_ptr = &kvm_get_tsc_info;
 # endif
     driver.get_vcpureg_ptr = &kvm_get_vcpureg;
 # ifndef ENABLE_KVM_LEGACY

--- a/libvmi/driver/kvm/kvm_common.c
+++ b/libvmi/driver/kvm/kvm_common.c
@@ -185,13 +185,17 @@ kvm_test(
     struct vmi_instance _vmi = {0};
     vmi_instance_t vmi = &_vmi;
 
-    if ( VMI_FAILURE == kvm_init(vmi, 0, NULL) )
+    if ( VMI_FAILURE == kvm_init(vmi, 0, NULL) ) {
+        kvm_destroy(vmi);
         return VMI_FAILURE;
+    }
 
     if (name) {
         domainid = kvm_get_id_from_name(vmi, name);
-        if (domainid != VMI_INVALID_DOMID)
+        if (domainid != VMI_INVALID_DOMID) {
+            kvm_destroy(vmi);
             return VMI_SUCCESS;
+        }
     }
 
     if (domainid != VMI_INVALID_DOMID) {
@@ -199,8 +203,10 @@ kvm_test(
         status_t rc = kvm_get_name_from_id(vmi, domainid, &_name);
         free(_name);
 
-        if ( VMI_SUCCESS == rc )
-            return rc;
+        if ( VMI_SUCCESS == rc ) {
+            kvm_destroy(vmi);
+           return rc;
+        }
     }
 
     kvm_destroy(vmi);

--- a/libvmi/driver/kvm/kvm_common.c
+++ b/libvmi/driver/kvm/kvm_common.c
@@ -205,7 +205,7 @@ kvm_test(
 
         if ( VMI_SUCCESS == rc ) {
             kvm_destroy(vmi);
-           return rc;
+            return rc;
         }
     }
 

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -36,57 +36,61 @@ fill_ev_common_kvmi_to_libvmi(
     struct kvmi_dom_event *kvmi_event,
     vmi_event_t *libvmi_event)
 {
+    x86_registers_t x86_regs = {0};
     //      standard regs
-    libvmi_event->x86_regs->rax = kvmi_event->event.common.arch.regs.rax;
-    libvmi_event->x86_regs->rbx = kvmi_event->event.common.arch.regs.rbx;
-    libvmi_event->x86_regs->rcx = kvmi_event->event.common.arch.regs.rcx;
-    libvmi_event->x86_regs->rdx = kvmi_event->event.common.arch.regs.rdx;
-    libvmi_event->x86_regs->rsi = kvmi_event->event.common.arch.regs.rsi;
-    libvmi_event->x86_regs->rdi = kvmi_event->event.common.arch.regs.rdi;
-    libvmi_event->x86_regs->rip = kvmi_event->event.common.arch.regs.rip;
-    libvmi_event->x86_regs->rsp = kvmi_event->event.common.arch.regs.rsp;
-    libvmi_event->x86_regs->rbp = kvmi_event->event.common.arch.regs.rbp;
-    libvmi_event->x86_regs->rflags = kvmi_event->event.common.arch.regs.rflags;
-    libvmi_event->x86_regs->r8 = kvmi_event->event.common.arch.regs.r8;
-    libvmi_event->x86_regs->r9 = kvmi_event->event.common.arch.regs.r9;
-    libvmi_event->x86_regs->r10 = kvmi_event->event.common.arch.regs.r10;
-    libvmi_event->x86_regs->r11 = kvmi_event->event.common.arch.regs.r11;
-    libvmi_event->x86_regs->r12 = kvmi_event->event.common.arch.regs.r12;
-    libvmi_event->x86_regs->r13 = kvmi_event->event.common.arch.regs.r13;
-    libvmi_event->x86_regs->r14 = kvmi_event->event.common.arch.regs.r14;
-    libvmi_event->x86_regs->r15 = kvmi_event->event.common.arch.regs.r15;
+    x86_regs.rax = kvmi_event->event.common.arch.regs.rax;
+    x86_regs.rbx = kvmi_event->event.common.arch.regs.rbx;
+    x86_regs.rcx = kvmi_event->event.common.arch.regs.rcx;
+    x86_regs.rdx = kvmi_event->event.common.arch.regs.rdx;
+    x86_regs.rsi = kvmi_event->event.common.arch.regs.rsi;
+    x86_regs.rdi = kvmi_event->event.common.arch.regs.rdi;
+    x86_regs.rip = kvmi_event->event.common.arch.regs.rip;
+    x86_regs.rsp = kvmi_event->event.common.arch.regs.rsp;
+    x86_regs.rbp = kvmi_event->event.common.arch.regs.rbp;
+    x86_regs.rflags = kvmi_event->event.common.arch.regs.rflags;
+    x86_regs.r8 = kvmi_event->event.common.arch.regs.r8;
+    x86_regs.r9 = kvmi_event->event.common.arch.regs.r9;
+    x86_regs.r10 = kvmi_event->event.common.arch.regs.r10;
+    x86_regs.r11 = kvmi_event->event.common.arch.regs.r11;
+    x86_regs.r12 = kvmi_event->event.common.arch.regs.r12;
+    x86_regs.r13 = kvmi_event->event.common.arch.regs.r13;
+    x86_regs.r14 = kvmi_event->event.common.arch.regs.r14;
+    x86_regs.r15 = kvmi_event->event.common.arch.regs.r15;
     //      special regs
     //          Control Registers
-    libvmi_event->x86_regs->cr0 = kvmi_event->event.common.arch.sregs.cr0;
-    libvmi_event->x86_regs->cr2 = kvmi_event->event.common.arch.sregs.cr2;
-    libvmi_event->x86_regs->cr3 = kvmi_event->event.common.arch.sregs.cr3;
-    libvmi_event->x86_regs->cr4 = kvmi_event->event.common.arch.sregs.cr4;
+    x86_regs.cr0 = kvmi_event->event.common.arch.sregs.cr0;
+    x86_regs.cr2 = kvmi_event->event.common.arch.sregs.cr2;
+    x86_regs.cr3 = kvmi_event->event.common.arch.sregs.cr3;
+    x86_regs.cr4 = kvmi_event->event.common.arch.sregs.cr4;
     //          CS
-    libvmi_event->x86_regs->cs_base = kvmi_event->event.common.arch.sregs.cs.base;
-    libvmi_event->x86_regs->cs_limit = kvmi_event->event.common.arch.sregs.cs.limit;
-    libvmi_event->x86_regs->cs_sel = kvmi_event->event.common.arch.sregs.cs.selector;
+    x86_regs.cs_base = kvmi_event->event.common.arch.sregs.cs.base;
+    x86_regs.cs_limit = kvmi_event->event.common.arch.sregs.cs.limit;
+    x86_regs.cs_sel = kvmi_event->event.common.arch.sregs.cs.selector;
     //          DS
-    libvmi_event->x86_regs->ds_base = kvmi_event->event.common.arch.sregs.ds.base;
-    libvmi_event->x86_regs->ds_limit = kvmi_event->event.common.arch.sregs.ds.limit;
-    libvmi_event->x86_regs->ds_sel = kvmi_event->event.common.arch.sregs.ds.selector;
+    x86_regs.ds_base = kvmi_event->event.common.arch.sregs.ds.base;
+    x86_regs.ds_limit = kvmi_event->event.common.arch.sregs.ds.limit;
+    x86_regs.ds_sel = kvmi_event->event.common.arch.sregs.ds.selector;
     //          SS
-    libvmi_event->x86_regs->ss_base = kvmi_event->event.common.arch.sregs.ss.base;
-    libvmi_event->x86_regs->ss_limit = kvmi_event->event.common.arch.sregs.ss.limit;
-    libvmi_event->x86_regs->ss_sel = kvmi_event->event.common.arch.sregs.ss.selector;
+    x86_regs.ss_base = kvmi_event->event.common.arch.sregs.ss.base;
+    x86_regs.ss_limit = kvmi_event->event.common.arch.sregs.ss.limit;
+    x86_regs.ss_sel = kvmi_event->event.common.arch.sregs.ss.selector;
     //          ES
-    libvmi_event->x86_regs->es_base = kvmi_event->event.common.arch.sregs.es.base;
-    libvmi_event->x86_regs->es_limit = kvmi_event->event.common.arch.sregs.es.limit;
-    libvmi_event->x86_regs->es_sel = kvmi_event->event.common.arch.sregs.es.selector;
+    x86_regs.es_base = kvmi_event->event.common.arch.sregs.es.base;
+    x86_regs.es_limit = kvmi_event->event.common.arch.sregs.es.limit;
+    x86_regs.es_sel = kvmi_event->event.common.arch.sregs.es.selector;
     //          FS
-    libvmi_event->x86_regs->fs_base = kvmi_event->event.common.arch.sregs.fs.base;
-    libvmi_event->x86_regs->fs_limit = kvmi_event->event.common.arch.sregs.fs.limit;
-    libvmi_event->x86_regs->fs_sel = kvmi_event->event.common.arch.sregs.fs.selector;
+    x86_regs.fs_base = kvmi_event->event.common.arch.sregs.fs.base;
+    x86_regs.fs_limit = kvmi_event->event.common.arch.sregs.fs.limit;
+    x86_regs.fs_sel = kvmi_event->event.common.arch.sregs.fs.selector;
     //          GS
-    libvmi_event->x86_regs->gs_base = kvmi_event->event.common.arch.sregs.gs.base;
-    libvmi_event->x86_regs->gs_limit = kvmi_event->event.common.arch.sregs.gs.limit;
-    libvmi_event->x86_regs->gs_sel = kvmi_event->event.common.arch.sregs.gs.selector;
+    x86_regs.gs_base = kvmi_event->event.common.arch.sregs.gs.base;
+    x86_regs.gs_limit = kvmi_event->event.common.arch.sregs.gs.limit;
+    x86_regs.gs_sel = kvmi_event->event.common.arch.sregs.gs.selector;
+    // reassign x86_regs
+    (*libvmi_event->x86_regs) = x86_regs;
     //      VCPU
     libvmi_event->vcpu_id = kvmi_event->event.common.vcpu;
+
 }
 
 static status_t

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -126,19 +126,6 @@ process_cb_response(
             }
         }
     }
-    // the rpl struct should be like this
-    //    struct {
-    //        struct kvmi_vcpu_hdr hdr;
-    //        struct kvmi_event_reply common;
-    //        // Event specific structs
-    //        ...
-    //    };
-    struct kvmi_vcpu_hdr *hdr = (struct kvmi_vcpu_hdr *)rpl;
-    hdr->vcpu = kvmi_event->event.common.vcpu;
-
-    struct kvmi_event_reply *common = (struct kvmi_event_reply *)( hdr + 1 );
-    common->event = kvmi_event->event.common.event;
-    common->action = KVMI_EVENT_ACTION_CONTINUE;
 
     if (kvm->libkvmi.kvmi_reply_event(kvm->kvmi_dom, kvmi_event->seq, rpl, rpl_size))
         return VMI_FAILURE;
@@ -219,6 +206,11 @@ process_register(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         struct kvmi_event_cr_reply cr;
     } rpl = {0};
 
+    // set reply action
+    rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
+    rpl.common.event = kvmi_event->event.common.event;
+    rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
+
     // the reply value will override the existing one
     rpl.cr.new_val = libvmi_event->reg_event.value;
 
@@ -286,8 +278,14 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         struct kvmi_event_msr_reply msr;
     } rpl = {0};
 
+    // set reply action
+    rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
+    rpl.common.event = kvmi_event->event.common.event;
+    rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
+
     // the reply value will override the existing one
     rpl.msr.new_val = libvmi_event->reg_event.value;
+
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }
 
@@ -336,6 +334,11 @@ process_interrupt(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         struct kvmi_event_reply common;
     } rpl = {0};
 
+    // set reply action
+    rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
+    rpl.common.event = kvmi_event->event.common.event;
+    rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
+
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }
 
@@ -353,6 +356,13 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     if (kvmi_event->event.page_fault.access & KVMI_PAGE_ACCESS_R) out_access |= VMI_MEMACCESS_R;
     if (kvmi_event->event.page_fault.access & KVMI_PAGE_ACCESS_W) out_access |= VMI_MEMACCESS_W;
     if (kvmi_event->event.page_fault.access & KVMI_PAGE_ACCESS_X) out_access |= VMI_MEMACCESS_X;
+
+    // reply struct
+    struct {
+        struct kvmi_vcpu_hdr hdr;
+        struct kvmi_event_reply common;
+        struct kvmi_event_pf_reply pf;
+    } rpl = {0};
 
     vmi_event_t *libvmi_event;
     addr_t gfn = kvmi_event->event.page_fault.gpa >> vmi->page_shift;
@@ -379,12 +389,10 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
             // call user callback
             event_response_t response = call_event_callback(vmi, libvmi_event);
 
-            // reply struct
-            struct {
-                struct kvmi_vcpu_hdr hdr;
-                struct kvmi_event_reply common;
-                struct kvmi_event_pf_reply pf;
-            } rpl = {0};
+            // set reply action
+            rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
+            rpl.common.event = kvmi_event->event.common.event;
+            rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
 
             return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
         }
@@ -414,12 +422,10 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
                 // call user callback
                 event_response_t response = call_event_callback(vmi, libvmi_event);
 
-                // struct reply
-                struct {
-                    struct kvmi_vcpu_hdr hdr;
-                    struct kvmi_event_reply common;
-                    struct kvmi_event_pf_reply pf;
-                } rpl = {0};
+                // set reply action
+                rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
+                rpl.common.event = kvmi_event->event.common.event;
+                rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
 
                 if (VMI_FAILURE ==
                         process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl)))

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -269,10 +269,10 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     fill_ev_common_kvmi_to_libvmi(kvmi_event, libvmi_event);
 
     //      msr_event
+    // TODO: only handle write accesses for now
+    libvmi_event->reg_event.out_access = VMI_REGACCESS_W;
     libvmi_event->reg_event.value = kvmi_event->event.msr.new_value;
     libvmi_event->reg_event.previous = kvmi_event->event.msr.old_value;
-    // TODO
-    // libvmi_event->reg_event.out_access
 
     // call user callback
     event_response_t response = call_event_callback(vmi, libvmi_event);

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -217,10 +217,8 @@ process_register(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         struct kvmi_event_cr_reply cr;
     } rpl = {0};
 
-
-    // TODO: how can the callback specifiy a new value for the MSR ?
-    // libvmi_event.reg_event.xxx
-    rpl.cr.new_val = kvmi_event->event.cr.new_value;
+    // the reply value will override the existing one
+    rpl.cr.new_val = libvmi_event->reg_event.value;
 
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }
@@ -286,12 +284,8 @@ process_msr(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
         struct kvmi_event_msr_reply msr;
     } rpl = {0};
 
-    // TODO: how can the callback specifiy a new value for the MSR ?
-    // libvmi_event.reg_event.xxx
-
-    // the reply new value will be used anyway,
-    // write the new val from the kvmi event
-    rpl.msr.new_val = kvmi_event->event.msr.new_value;
+    // the reply value will override the existing one
+    rpl.msr.new_val = libvmi_event->reg_event.value;
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }
 

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -340,7 +340,6 @@ process_interrupt(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     libvmi_event->vcpu_id = kvmi_event->event.common.vcpu;
 
     //      interrupt_event
-    // TODO: hardcoded PAGE_SHIFT
     libvmi_event->interrupt_event.gfn = kvmi_event->event.breakpoint.gpa >> vmi->page_shift;
     // TODO: vector and type
     // event->interrupt_event.vector =
@@ -397,8 +396,6 @@ process_pagefault(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     // lookup vmi_event
     //      standard ?
     if ( g_hash_table_size(vmi->mem_events_on_gfn) ) {
-        // TODO: hardcoded page shift
-
         libvmi_event = g_hash_table_lookup(vmi->mem_events_on_gfn, &gfn);
         if (libvmi_event && (libvmi_event->mem_event.in_access & out_access)) {
             // fill libvmi_event struct

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -572,7 +572,7 @@ kvm_events_listen(
 #ifdef ENABLE_SAFETY_CHECKS
     if ( ev_reason >= KVMI_NUM_EVENTS || !kvm->process_event[ev_reason] ) {
         errprint("Undefined handler for %u event reason\n", ev_reason);
-        return VMI_FAILURE;
+        goto error_exit;
     }
 #endif
     // call handler

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -799,9 +799,6 @@ kvm_set_reg_access(
             for (size_t msr_i=0; msr_i<msr_all_len; msr_i++) {
                 kvmi_reg = msr_index[msr_all[msr_i]];
                 if (kvm->libkvmi.kvmi_control_msr(kvm->kvmi_dom, vcpu, kvmi_reg, enabled)) {
-                    // this call fails on MSR_HYPERVISOR
-                    // to avoid breaking MSR_ALL feature, we simply continue
-                    // and print an error message
                     errprint("%s: failed to set MSR event for %s: %s\n", __func__,
                              msr_to_str[msr_all[msr_i]], strerror(errno));
                     continue;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -337,7 +337,13 @@ process_interrupt(vmi_instance_t vmi, struct kvmi_dom_event *kvmi_event)
     // set reply action
     rpl.hdr.vcpu = kvmi_event->event.common.vcpu;
     rpl.common.event = kvmi_event->event.common.event;
-    rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
+    // default action is RETRY: KVM will re-enter the guest
+    rpl.common.action = KVMI_EVENT_ACTION_RETRY;
+
+    // action CONTINUE: KVM should handle the event as if
+    // the introspection tool did nothing (reinject int3)
+    if (libvmi_event->interrupt_event.reinject)
+        rpl.common.action = KVMI_EVENT_ACTION_CONTINUE;
 
     return process_cb_response(vmi, response, libvmi_event, kvmi_event, &rpl, sizeof(rpl));
 }

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -684,8 +684,10 @@ kvm_events_listen(
         // since they have to managed by vmi_resume_vm(), we simply store them
         // in the kvm_instance for later use by this function
         if (KVMI_EVENT_PAUSE_VCPU == ev_reason) {
-            uint16_t vcpu = event->event.common.vcpu;
 #ifdef ENABLE_SAFETY_CHECKS
+            uint16_t vcpu = event->event.common.vcpu;
+            // silence unused variable warnings if not asserts
+            (void)vcpu;
             assert(vcpu < vmi->num_vcpus);
 #endif
             kvm->pause_events_list[event->event.common.vcpu] = event;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -630,6 +630,8 @@ kvm_events_destroy(
     }
 #endif
     // disable CR/MSR monitoring
+    dbprint(VMI_DEBUG_KVM, "--Destroying KVM driver events\n");
+    
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, false))
             errprint("--Failed to disable CR monitoring\n");

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -631,7 +631,7 @@ kvm_events_destroy(
 #endif
     // disable CR/MSR monitoring
     dbprint(VMI_DEBUG_KVM, "--Destroying KVM driver events\n");
-    
+
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, false))
             errprint("--Failed to disable CR monitoring\n");

--- a/libvmi/driver/kvm/kvm_events.h
+++ b/libvmi/driver/kvm/kvm_events.h
@@ -60,4 +60,8 @@ kvm_set_mem_access(
     vmi_mem_access_t page_access_flag,
     uint16_t vmm_pagetable_id);
 
+status_t kvm_set_desc_access_event(
+    vmi_instance_t,
+    bool enabled);
+
 #endif // KVM_EVENTS_H

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -1,3 +1,4 @@
+
 /* The LibVMI Library is an introspection library that simplifies access to
  * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
@@ -55,6 +56,9 @@ typedef struct kvm_instance {
     pthread_mutex_t kvm_connect_mutex;
     pthread_cond_t kvm_start_cond;
     unsigned int expected_pause_count;
+    // store KVMI_EVENT_PAUSE_VCPU events poped by vmi_events_listen(vmi, 0)
+    // to be used by vmi_resume_vm()
+    struct kvmi_dom_event** pause_events_list;
     // dispatcher to handle VM events in each process_xxx functions
     status_t (*process_event[KVMI_NUM_EVENTS])(vmi_instance_t vmi, struct kvmi_dom_event *event);
 #endif

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -79,4 +79,13 @@ kvm_put_memory(vmi_instance_t vmi,
                uint32_t length,
                void *buf);
 
+// shared by kvm.c and kvm_events.c
+# ifndef ENABLE_KVM_LEGACY
+void
+kvmi_regs_to_libvmi(
+    struct kvm_regs *kvmi_regs,
+    struct kvm_sregs *kvmi_sregs,
+    x86_registers_t *libvmi_regs);
+# endif
+
 #endif

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -32,7 +32,7 @@ static status_t sanity_check(kvm_instance_t *kvm)
             !w->kvmi_get_version || !w->kvmi_control_events ||
             !w->kvmi_control_vm_events || !w->kvmi_control_cr ||
             !w->kvmi_control_msr || !w->kvmi_pause_all_vcpus ||
-            !w->kvmi_get_page_access || !w->kvmi_set_page_access ||
+            !w->kvmi_get_page_access || !w->kvmi_set_page_access || !w->kvmi_get_tsc_speed ||
             !w->kvmi_get_vcpu_count || !w->kvmi_inject_exception ||
             !w->kvmi_read_physical || !w->kvmi_write_physical ||
             !w->kvmi_get_registers || !w->kvmi_set_registers ||
@@ -70,6 +70,7 @@ status_t create_libkvmi_wrapper(struct kvm_instance *kvm)
     wrapper->kvmi_pause_all_vcpus = dlsym(wrapper->handle, "kvmi_pause_all_vcpus");
     wrapper->kvmi_get_page_access = dlsym(wrapper->handle, "kvmi_get_page_access");
     wrapper->kvmi_set_page_access = dlsym(wrapper->handle, "kvmi_set_page_access");
+    wrapper->kvmi_get_tsc_speed = dlsym(wrapper->handle, "kvmi_get_tsc_speed");
     wrapper->kvmi_get_vcpu_count = dlsym(wrapper->handle, "kvmi_get_vcpu_count");
     wrapper->kvmi_inject_exception = dlsym(wrapper->handle, "kvmi_inject_exception");
     wrapper->kvmi_read_physical = dlsym(wrapper->handle, "kvmi_read_physical");

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -37,7 +37,7 @@ static status_t sanity_check(kvm_instance_t *kvm)
             !w->kvmi_read_physical || !w->kvmi_write_physical ||
             !w->kvmi_get_registers || !w->kvmi_set_registers ||
             !w->kvmi_reply_event || !w->kvmi_pop_event || !w->kvmi_wait_event ||
-            !w->kvmi_get_maximum_gfn ) {
+            !w->kvmi_set_log_cb || !w->kvmi_get_maximum_gfn ) {
         dbprint(VMI_DEBUG_KVM, "--failed to find the required functions in libkvmi\n");
         return VMI_FAILURE;
     }
@@ -79,6 +79,7 @@ status_t create_libkvmi_wrapper(struct kvm_instance *kvm)
     wrapper->kvmi_reply_event = dlsym(wrapper->handle, "kvmi_reply_event");
     wrapper->kvmi_pop_event = dlsym(wrapper->handle, "kvmi_pop_event");
     wrapper->kvmi_wait_event = dlsym(wrapper->handle, "kvmi_wait_event");
+    wrapper->kvmi_set_log_cb = dlsym(wrapper->handle, "kvmi_set_log_cb");
     wrapper->kvmi_get_maximum_gfn = dlsym(wrapper->handle, "kvmi_get_maximum_gfn");
 
     status_t ret = sanity_check(kvm);

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -24,15 +24,20 @@
 
 static status_t sanity_check(kvm_instance_t *kvm)
 {
-    libkvmi_wrapper_t *w = &kvm->libkvmi;
+    libkvmi_wrapper_t *w =
+        &kvm->libkvmi;
 
     if ( !w->kvmi_init_unix_socket || !w->kvmi_uninit || !w->kvmi_close ||
-            !w->kvmi_domain_close || !w->kvmi_connection_fd || !w->kvmi_control_events || !w->kvmi_control_vm_events ||
-            !w->kvmi_control_cr || !w->kvmi_control_msr || !w->kvmi_pause_all_vcpus ||
-            !w->kvmi_get_page_access || !w->kvmi_set_page_access || !w->kvmi_get_vcpu_count ||
-            !w->kvmi_inject_exception || !w->kvmi_read_physical || !w->kvmi_write_physical ||
-            !w->kvmi_get_registers || !w->kvmi_set_registers || !w->kvmi_reply_event ||
-            !w->kvmi_pop_event || !w->kvmi_wait_event || !w->kvmi_get_maximum_gfn ) {
+            !w->kvmi_domain_close || !w->kvmi_connection_fd ||
+            !w->kvmi_get_version || !w->kvmi_control_events ||
+            !w->kvmi_control_vm_events || !w->kvmi_control_cr ||
+            !w->kvmi_control_msr || !w->kvmi_pause_all_vcpus ||
+            !w->kvmi_get_page_access || !w->kvmi_set_page_access ||
+            !w->kvmi_get_vcpu_count || !w->kvmi_inject_exception ||
+            !w->kvmi_read_physical || !w->kvmi_write_physical ||
+            !w->kvmi_get_registers || !w->kvmi_set_registers ||
+            !w->kvmi_reply_event || !w->kvmi_pop_event || !w->kvmi_wait_event ||
+            !w->kvmi_get_maximum_gfn ) {
         dbprint(VMI_DEBUG_KVM, "--failed to find the required functions in libkvmi\n");
         return VMI_FAILURE;
     }
@@ -57,6 +62,7 @@ status_t create_libkvmi_wrapper(struct kvm_instance *kvm)
     wrapper->kvmi_close = dlsym(wrapper->handle, "kvmi_close");
     wrapper->kvmi_domain_close = dlsym(wrapper->handle, "kvmi_domain_close");
     wrapper->kvmi_connection_fd = dlsym(wrapper->handle, "kvmi_connection_fd");
+    wrapper->kvmi_get_version = dlsym(wrapper->handle, "kvmi_get_version");
     wrapper->kvmi_control_events = dlsym(wrapper->handle, "kvmi_control_events");
     wrapper->kvmi_control_vm_events = dlsym(wrapper->handle, "kvmi_control_vm_events");
     wrapper->kvmi_control_cr = dlsym(wrapper->handle, "kvmi_control_cr");

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -27,7 +27,7 @@ static status_t sanity_check(kvm_instance_t *kvm)
     libkvmi_wrapper_t *w = &kvm->libkvmi;
 
     if ( !w->kvmi_init_unix_socket || !w->kvmi_uninit || !w->kvmi_close ||
-            !w->kvmi_domain_close || !w->kvmi_control_events || !w->kvmi_control_vm_events ||
+            !w->kvmi_domain_close || !w->kvmi_connection_fd || !w->kvmi_control_events || !w->kvmi_control_vm_events ||
             !w->kvmi_control_cr || !w->kvmi_control_msr || !w->kvmi_pause_all_vcpus ||
             !w->kvmi_get_page_access || !w->kvmi_set_page_access || !w->kvmi_get_vcpu_count ||
             !w->kvmi_inject_exception || !w->kvmi_read_physical || !w->kvmi_write_physical ||
@@ -56,6 +56,7 @@ status_t create_libkvmi_wrapper(struct kvm_instance *kvm)
     wrapper->kvmi_uninit = dlsym(wrapper->handle, "kvmi_uninit");
     wrapper->kvmi_close = dlsym(wrapper->handle, "kvmi_close");
     wrapper->kvmi_domain_close = dlsym(wrapper->handle, "kvmi_domain_close");
+    wrapper->kvmi_connection_fd = dlsym(wrapper->handle, "kvmi_connection_fd");
     wrapper->kvmi_control_events = dlsym(wrapper->handle, "kvmi_control_events");
     wrapper->kvmi_control_vm_events = dlsym(wrapper->handle, "kvmi_control_vm_events");
     wrapper->kvmi_control_cr = dlsym(wrapper->handle, "kvmi_control_cr");

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -1,4 +1,24 @@
-
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "kvm_private.h"
 #include "libkvmi_wrapper.h"
 

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -47,6 +47,9 @@ typedef struct {
     int (*kvmi_connection_fd)
     ( const void *dom );
 
+    int (*kvmi_get_version)
+    ( void *dom, unsigned int *version );
+
     int (*kvmi_control_events)
     (void *dom, unsigned short vcpu, int id, bool enable);
 

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -99,6 +99,9 @@ typedef struct {
     int (*kvmi_wait_event)
     (void *dom, kvmi_timeout_t ms);
 
+    void (*kvmi_set_log_cb)
+    ( kvmi_log_cb cb, void *ctx );
+
     int (*kvmi_get_maximum_gfn)
     (void *dom, unsigned long long *gfn);
 

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -71,6 +71,9 @@ typedef struct {
     int (*kvmi_set_page_access)
     (void *dom, unsigned long long int *gpa, unsigned char *access, unsigned short count);
 
+    int (*kvmi_get_tsc_speed)
+    (void *dom, unsigned long long int *speed);
+
     int (*kvmi_get_vcpu_count)
     (void *dom, unsigned int *count);
 

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -44,6 +44,9 @@ typedef struct {
     void (*kvmi_domain_close)
     (void *dom, bool do_shutdown);
 
+    int (*kvmi_connection_fd)
+    ( const void *dom );
+
     int (*kvmi_control_events)
     (void *dom, unsigned short vcpu, int id, bool enable);
 

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -1,3 +1,24 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Mathieu Tarral (mathieu.tarral@ssi.gouv.fr)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef LIBKVMI_WRAPPER_H
 #define LIBKVMI_WRAPPER_H
 

--- a/libvmi/msr-index.c
+++ b/libvmi/msr-index.c
@@ -1,3 +1,24 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "msr-index.h"
 
 const reg_t msr_all[] = {


### PR DESCRIPTION
This PR fixes the remarks from https://github.com/libvmi/libvmi/pull/844
and adds a few features:

- descriptor events support
- `fool-patchguard` example
- TSC speed
- README with the Libvmi API implementation status for KVM driver