### PR TITLE
Kvmi clean shutdown

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -953,14 +953,12 @@ kvm_resume_vm(
 
         // if no pause event is waiting in the list, pop next one
         if (!ev) {
-            // wait
-            if (kvm->libkvmi.kvmi_wait_event(kvm->kvmi_dom, 1000)) {
-                errprint("%s: Failed to receive event\n", __func__);
-                return VMI_FAILURE;
+            if (VMI_FAILURE == kvm_get_next_event(kvm, &ev, 3000)) {
+                errprint("Failed to get next KVMi event\n");
             }
-            // pop
-            if (kvm->libkvmi.kvmi_pop_event(kvm->kvmi_dom, &ev)) {
-                errprint("%s: Failed to pop event\n", __func__);
+            if (!ev) {
+                // no new events
+                // report error
                 return VMI_FAILURE;
             }
         }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -945,6 +945,7 @@ kvm_resume_vm(
         // check pause events poped by vmi_events_listen first
         for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
             if (kvm->pause_events_list[vcpu]) {
+                dbprint(VMI_DEBUG_KVM, "--Removing PAUSE_VCPU event from the buffer\n");
                 ev = kvm->pause_events_list[vcpu];
                 kvm->pause_events_list[vcpu] = NULL;
                 break;
@@ -953,7 +954,7 @@ kvm_resume_vm(
 
         // if no pause event is waiting in the list, pop next one
         if (!ev) {
-            if (VMI_FAILURE == kvm_get_next_event(kvm, &ev, 3000)) {
+            if (VMI_FAILURE == kvm_get_next_event(kvm, &ev, 1000)) {
                 errprint("Failed to get next KVMi event\n");
             }
             if (!ev) {

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -765,6 +765,7 @@ kvm_events_listen(
             (void)vcpu;
             assert(vcpu < vmi->num_vcpus);
 #endif
+            dbprint(VMI_DEBUG_KVM, "--Moving PAUSE_VPCU event in the buffer\n");
             kvm->pause_events_list[event->event.common.vcpu] = event;
             event = NULL;
             continue;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -660,6 +660,11 @@ kvm_events_destroy(
         kvm_set_intr_access(vmi, &intrevent, false);
     }
 
+    if (kvm->monitor_desc_on) {
+        // disable descriptor
+        kvm_set_desc_access_event(vmi, false);
+    }
+
     // disable CR/MSR interception
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, false))

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -648,6 +648,12 @@ kvm_events_destroy(
         kvm_set_reg_access(vmi, &regevent);
     }
 
+    if (kvm->monitor_msr_all_on) {
+        // disable MSR_ALL
+        regevent.reg = MSR_ALL;
+        kvm_set_reg_access(vmi, &regevent);
+    }
+
     // disable CR/MSR interception
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, false))
@@ -846,7 +852,8 @@ kvm_set_reg_access(
             }
         }
         kvm->monitor_msr_all_on = enabled;
-        dbprint(VMI_DEBUG_KVM, "--Set MSR events on all MSRs\n");
+        dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on all MSRs\n",
+                (enabled ? "enabling" : "disabling"));
     }
 
     return VMI_SUCCESS;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -1023,7 +1023,6 @@ status_t kvm_set_desc_access_event(
 #endif
 
     kvm_instance_t *kvm = kvm_get_instance(vmi);
-    dbprint(VMI_DEBUG_KVM, "--%s descriptor monitoring\n", (enabled) ? "Enable" : "Disable");
 
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_DESCRIPTOR, enabled)) {
@@ -1032,6 +1031,7 @@ status_t kvm_set_desc_access_event(
         }
     }
 
+    dbprint(VMI_DEBUG_KVM, "--%s descriptor monitoring\n", (enabled) ? "Enabled" : "Disabled");
     kvm->monitor_desc_on = enabled;
 
     return VMI_SUCCESS;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -775,9 +775,11 @@ kvm_events_listen(
             goto error_exit;
         }
 #endif
-        // call handler
-        if (VMI_FAILURE == kvm->process_event[ev_reason](vmi, event))
-            goto error_exit;
+        if (!vmi->shutting_down) {
+            // call handler
+            if (VMI_FAILURE == kvm->process_event[ev_reason](vmi, event))
+                goto error_exit;
+        }
     } while (process_all_events);
 
     return VMI_SUCCESS;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -628,6 +628,11 @@ kvm_events_destroy(
     }
 #endif
     dbprint(VMI_DEBUG_KVM, "--Destroying KVM driver events\n");
+    // pause VM
+    dbprint(VMI_DEBUG_KVM, "--Ensure VM is paused\n");
+    if (VMI_FAILURE == vmi_pause_vm(vmi))
+        errprint("--Failed to pause VM while destroying events\n");
+
     // disable CR0/3/4 monitoring if needed
     reg_event_t regevent = { .in_access = VMI_REGACCESS_N };
     if (kvm->monitor_cr0_on) {
@@ -672,6 +677,11 @@ kvm_events_destroy(
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_MSR, false))
             errprint("--Failed to disable MSR interception\n");
     }
+
+    // resume VM
+    dbprint(VMI_DEBUG_KVM, "--Resume VM\n");
+    if (VMI_FAILURE == vmi_resume_vm(vmi))
+        errprint("--Failed to resume VM while destroying events\n");
 }
 
 status_t

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -794,6 +794,18 @@ kvm_set_reg_access(
                     goto error_exit;
                 }
         }
+        // monitoring has been enabled
+        switch (event->reg) {
+            case CR0:
+                kvm->monitor_cr0_on = enabled;
+                break;
+            case CR3:
+                kvm->monitor_cr3_on = enabled;
+                break;
+            case CR4:
+                kvm->monitor_cr4_on = enabled;
+                break;
+        }
         dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on register %" PRIu64"\n",
                 (enabled ? "enabling" : "disabling"),
                 event->reg);

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -892,6 +892,7 @@ kvm_set_intr_access(
                     errprint("%s: failed to set event on VCPU %u: %s\n", __func__, vcpu, strerror(errno));
                     goto error_exit;
                 }
+            kvm->monitor_intr_on = enabled;
             break;
         default:
             errprint("KVM driver does not support enabling events for interrupt: %"PRIu32"\n", event->intr);

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -1027,6 +1027,8 @@ status_t kvm_set_desc_access_event(
         }
     }
 
+    kvm->monitor_desc_on = enabled;
+
     return VMI_SUCCESS;
 
 error_exit:

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -781,6 +781,9 @@ kvm_events_listen(
             if (VMI_FAILURE == kvm->process_event[ev_reason](vmi, event))
                 goto error_exit;
         }
+        // free event
+        if (event)
+            free(event);
     } while (process_all_events);
 
     return VMI_SUCCESS;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -895,6 +895,8 @@ kvm_set_reg_access(
                 errprint("--Unexpected value for reg: %" PRIu64 "\n", event->reg);
                 goto error_exit;
         }
+        // silence unused variable if debug disabled
+        (void)cr_reg_str;
         dbprint(VMI_DEBUG_KVM, "--%s monitoring on register %s\n",
                 (enabled ? "Enabling" : "Disabling"),
                 cr_reg_str);
@@ -1037,6 +1039,8 @@ kvm_set_mem_access(
     if (kvmi_access & KVMI_PAGE_ACCESS_W) str_access[1] = 'W';
     if (kvmi_access & KVMI_PAGE_ACCESS_X) str_access[2] = 'X';
 
+    // silence unused variable if debug disabled
+    (void)str_access;
     dbprint(VMI_DEBUG_KVM, "--Setting memaccess permissions to %s on GPFN: 0x%" PRIx64 "\n", str_access, gpfn);
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -591,17 +591,17 @@ kvm_events_init(
     kvm->process_event[KVMI_EVENT_DESCRIPTOR] = &process_descriptor;
     kvm->process_event[KVMI_EVENT_PAUSE_VCPU] = &process_pause_event;
 
-    // enable monitoring of CR and MSR for all VCPUs by default
+    // enable interception of CR and MSR for all VCPUs by default
     // since this has no performance cost
     // the interception is activated only when specific registers
     // have been defined via kvmi_control_cr(), kvmi_control_msr()
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, true)) {
-            errprint("--Failed to enable CR monitoring\n");
+            errprint("--Failed to enable CR interception\n");
             goto err_exit;
         }
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_MSR, true)) {
-            errprint("--Failed to enable MSR monitoring\n");
+            errprint("--Failed to enable MSR interception\n");
             goto err_exit;
         }
     }

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -633,7 +633,6 @@ kvm_events_destroy(
     if (VMI_FAILURE == vmi_pause_vm(vmi))
         errprint("--Failed to pause VM while destroying events\n");
 
-    // disable CR0/3/4 monitoring if needed
     reg_event_t regevent = { .in_access = VMI_REGACCESS_N };
     if (kvm->monitor_cr0_on) {
         // disable CR0

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -812,20 +812,27 @@ kvm_set_reg_access(
                 }
         }
         // monitoring has been enabled
+        char *cr_reg_str = NULL;
         switch (event->reg) {
             case CR0:
                 kvm->monitor_cr0_on = enabled;
+                cr_reg_str = "CR0";
                 break;
             case CR3:
                 kvm->monitor_cr3_on = enabled;
+                cr_reg_str = "CR3";
                 break;
             case CR4:
                 kvm->monitor_cr4_on = enabled;
+                cr_reg_str = "CR4";
                 break;
+            default:
+                errprint("--Unexpected value for reg: %" PRIu64 "\n", event->reg);
+                goto error_exit;
         }
-        dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on register %" PRIu64"\n",
+        dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on register %s\n",
                 (enabled ? "enabling" : "disabling"),
-                event->reg);
+                cr_reg_str);
     } else {
         // MSR_ALL
         for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -836,8 +836,8 @@ kvm_set_reg_access(
                 errprint("--Unexpected value for reg: %" PRIu64 "\n", event->reg);
                 goto error_exit;
         }
-        dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on register %s\n",
-                (enabled ? "enabling" : "disabling"),
+        dbprint(VMI_DEBUG_KVM, "--%s monitoring on register %s\n",
+                (enabled ? "Enabling" : "Disabling"),
                 cr_reg_str);
     } else {
         // MSR_ALL
@@ -852,8 +852,8 @@ kvm_set_reg_access(
             }
         }
         kvm->monitor_msr_all_on = enabled;
-        dbprint(VMI_DEBUG_KVM, "--Done %s monitoring on all MSRs\n",
-                (enabled ? "enabling" : "disabling"));
+        dbprint(VMI_DEBUG_KVM, "--%s monitoring on all MSRs\n",
+                (enabled ? "Enabling" : "Disabling"));
     }
 
     return VMI_SUCCESS;
@@ -995,7 +995,7 @@ kvm_set_mem_access(
         return VMI_FAILURE;
     }
 
-    dbprint(VMI_DEBUG_KVM, "--Done setting memaccess on GPFN: 0x%" PRIx64 "\n", gpfn);
+    dbprint(VMI_DEBUG_KVM, "--Setting memaccess on GPFN: 0x%" PRIx64 "\n", gpfn);
     return VMI_SUCCESS;
 }
 

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -845,6 +845,7 @@ kvm_set_reg_access(
                 }
             }
         }
+        kvm->monitor_msr_all_on = enabled;
         dbprint(VMI_DEBUG_KVM, "--Set MSR events on all MSRs\n");
     }
 

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -1006,7 +1006,12 @@ kvm_set_mem_access(
         return VMI_FAILURE;
     }
 
-    dbprint(VMI_DEBUG_KVM, "--Setting memaccess on GPFN: 0x%" PRIx64 "\n", gpfn);
+    char str_access[4] = {'_', '_', '_', '\0'};
+    if (kvmi_access & KVMI_PAGE_ACCESS_R) str_access[0] = 'R';
+    if (kvmi_access & KVMI_PAGE_ACCESS_W) str_access[1] = 'W';
+    if (kvmi_access & KVMI_PAGE_ACCESS_X) str_access[2] = 'X';
+
+    dbprint(VMI_DEBUG_KVM, "--Setting memaccess permissions to %s on GPFN: 0x%" PRIx64 "\n", str_access, gpfn);
     return VMI_SUCCESS;
 }
 

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -973,7 +973,7 @@ kvm_set_mem_access(
     // check access type and convert to KVMI
     switch (page_access_flag) {
         case VMI_MEMACCESS_N:
-            kvmi_access = 0;
+            kvmi_access = KVMI_PAGE_ACCESS_R | KVMI_PAGE_ACCESS_W | KVMI_PAGE_ACCESS_X;
             break;
         case VMI_MEMACCESS_R:
             kvmi_access = kvmi_orig_access & ~KVMI_PAGE_ACCESS_R;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -678,6 +678,11 @@ kvm_events_destroy(
             errprint("--Failed to disable MSR interception\n");
     }
 
+    // clean event queue
+    dbprint(VMI_DEBUG_KVM, "--Cleanup event queue\n");
+    if (VMI_FAILURE == vmi_events_listen(vmi, 0))
+        errprint("--Failed to clean event queue\n");
+
     // resume VM
     dbprint(VMI_DEBUG_KVM, "--Resume VM\n");
     if (VMI_FAILURE == vmi_resume_vm(vmi))

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -742,6 +742,7 @@ kvm_events_listen(
 #endif
 
     do {
+        event = NULL;
         if (VMI_FAILURE == kvm_get_next_event(kvm, &event, (kvmi_timeout_t)timeout)) {
             errprint("%s: Failed to get next KVMi event: %s\n", __func__, strerror(errno));
             goto error_exit;

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -654,6 +654,12 @@ kvm_events_destroy(
         kvm_set_reg_access(vmi, &regevent);
     }
 
+    if (kvm->monitor_intr_on) {
+        // disable INT3
+        interrupt_event_t intrevent = { .intr = INT3 };
+        kvm_set_intr_access(vmi, &intrevent, false);
+    }
+
     // disable CR/MSR interception
     for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         if (kvm->libkvmi.kvmi_control_events(kvm->kvmi_dom, vcpu, KVMI_EVENT_CR, false))

--- a/libvmi/driver/kvm/kvm_events.h
+++ b/libvmi/driver/kvm/kvm_events.h
@@ -27,6 +27,7 @@
 #define KVM_EVENTS_H
 
 #include "private.h"
+#include "kvm_private.h"
 
 status_t
 kvm_events_init(
@@ -63,5 +64,11 @@ kvm_set_mem_access(
 status_t kvm_set_desc_access_event(
     vmi_instance_t,
     bool enabled);
+
+status_t
+kvm_get_next_event(
+    kvm_instance_t *kvm,
+    struct kvmi_dom_event **event,
+    kvmi_timeout_t timeout);
 
 #endif // KVM_EVENTS_H

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -64,6 +64,7 @@ typedef struct kvm_instance {
     bool monitor_cr0_on;
     bool monitor_cr3_on;
     bool monitor_cr4_on;
+    bool monitor_msr_all_on;
 #endif
 } kvm_instance_t;
 

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -66,6 +66,7 @@ typedef struct kvm_instance {
     bool monitor_cr4_on;
     bool monitor_msr_all_on;
     bool monitor_intr_on;
+    bool monitor_desc_on;
 #endif
 } kvm_instance_t;
 

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -65,6 +65,7 @@ typedef struct kvm_instance {
     bool monitor_cr3_on;
     bool monitor_cr4_on;
     bool monitor_msr_all_on;
+    bool monitor_intr_on;
 #endif
 } kvm_instance_t;
 

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -61,6 +61,9 @@ typedef struct kvm_instance {
     struct kvmi_dom_event** pause_events_list;
     // dispatcher to handle VM events in each process_xxx functions
     status_t (*process_event[KVMI_NUM_EVENTS])(vmi_instance_t vmi, struct kvmi_dom_event *event);
+    bool monitor_cr0_on;
+    bool monitor_cr3_on;
+    bool monitor_cr4_on;
 #endif
 } kvm_instance_t;
 


### PR DESCRIPTION
This PR cleans up the shutdown of KVM driver, by tracking the state of events, and disabling them on driver destroy if needed.

Also minor fixes.